### PR TITLE
TASK-004 – Utilidad ensure_pandoc() y pruebas unitarias

### DIFF
--- a/src/wiki_documental/__init__.py
+++ b/src/wiki_documental/__init__.py
@@ -1,0 +1,2 @@
+from .utils.system import ensure_pandoc
+

--- a/src/wiki_documental/utils/system.py
+++ b/src/wiki_documental/utils/system.py
@@ -1,0 +1,14 @@
+import shutil
+import subprocess
+
+
+def ensure_pandoc() -> None:
+    """Raise RuntimeError if pandoc is not in PATH."""
+    if shutil.which("pandoc") is None:
+        raise RuntimeError(
+            "Pandoc executable not found. Please install pandoc and ensure it is in PATH."
+        )
+    result = subprocess.run(["pandoc", "--version"], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError("Pandoc found but failed to execute.")
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,21 @@
+import subprocess
+import shutil
+import pytest
+
+from wiki_documental.utils.system import ensure_pandoc
+
+
+def test_missing_pandoc(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(RuntimeError):
+        ensure_pandoc()
+
+
+def test_pandoc_execution_failure(monkeypatch):
+    class DummyResult:
+        def __init__(self):
+            self.returncode = 1
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: DummyResult())
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/pandoc")
+    with pytest.raises(RuntimeError):
+        ensure_pandoc()


### PR DESCRIPTION
Se agrega la función `ensure_pandoc` en `wiki_documental.utils.system` para verificar la disponibilidad de Pandoc.
Esta utilidad será usada por la CLI para abortar la ejecución cuando Pandoc no esté instalado.

También se incorporan pruebas unitarias que validan los casos de ausencia del ejecutable y fallo al ejecutarlo.

------
https://chatgpt.com/codex/tasks/task_e_684a23181a048333b643620f181e0445