### PR TITLE
TASK-005 – CLI inicial con Typer y reexport de ensure_pandoc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ PyYAML = "^6.0"
 rich = "^13.7"
 python-slugify = "^8.0"
 tqdm = "^4.66"
+typer = {version = "^0.9", extras = ["all"]}
 
 [tool.poetry.extras]
 pdf = ["pdfminer.six", "pdf2image", "pytesseract"]
@@ -20,3 +21,6 @@ pdf = ["pdfminer.six", "pdf2image", "pytesseract"]
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
 pytest-cov = "^5.0"
+
+[tool.poetry.scripts]
+wiki = "wiki_documental.cli:app"

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -1,0 +1,47 @@
+import typer
+from rich.console import Console
+
+from . import ensure_pandoc
+
+app = typer.Typer(add_completion=False, add_help_option=True)
+
+__version__ = "0.1.0"
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"wiki_documental {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        None,
+        "--version",
+        "-v",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the application version and exit.",
+    )
+):
+    """Wiki Documental CLI."""
+    return
+
+
+@app.command()
+def full() -> None:
+    """Run full wiki generation (placeholder)."""
+    console = Console()
+    try:
+        ensure_pandoc()
+    except RuntimeError as exc:
+        console.print(str(exc), style="red")
+        raise typer.Exit(code=1)
+    console.print("Running full placeholder")
+
+
+@app.command()
+def reset() -> None:
+    """Reset wiki state (placeholder)."""
+    typer.echo("Running reset placeholder")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+import builtins
+
+from typer.testing import CliRunner
+
+from wiki_documental.cli import app
+
+runner = CliRunner()
+
+
+def test_version_option():
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "0.1.0" in result.stdout
+
+
+def test_full_calls_ensure_pandoc(monkeypatch):
+    called = {"value": False}
+
+    def dummy():
+        called["value"] = True
+
+    monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", dummy)
+    result = runner.invoke(app, ["full"])
+    assert result.exit_code == 0
+    assert called["value"]
+    assert "Running full placeholder" in result.stdout


### PR DESCRIPTION
Se ha creado la base de la CLI utilizando Typer, incorporando los comandos `full` y `reset` como placeholders. El flag `--version` muestra la versión `0.1.0`. El subcomando `full` verifica la presencia de Pandoc mediante `ensure_pandoc`, mostrando un mensaje de error con Rich en caso de fallo. Además, se ha añadido el punto de entrada `wiki` en el `pyproject.toml` y `ensure_pandoc` se puede importar desde el paquete `wiki_documental`.

------
https://chatgpt.com/codex/tasks/task_e_684a2809a5848333999e471c0888a987