### PR TITLE
TASK-006 – Configuración inicial y cargador de rutas

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,9 @@
+paths:
+  originals: "inputs/_originals"
+  work: "work"
+  wiki: "wiki"
+  tmp: "work/tmp"
+
+options:
+  ocr: false
+  cutoff_similarity: 0.5

--- a/src/wiki_documental/__init__.py
+++ b/src/wiki_documental/__init__.py
@@ -1,2 +1,3 @@
 from .utils.system import ensure_pandoc
+from .config import cfg  # noqa: F401
 

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -5,7 +5,7 @@ from . import ensure_pandoc
 
 app = typer.Typer(add_completion=False, add_help_option=True)
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 
 def _version_callback(value: bool) -> None:

--- a/src/wiki_documental/config.py
+++ b/src/wiki_documental/config.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_config() -> dict:
+    """Load configuration from config.yaml and ensure directories exist."""
+    cfg_file = ROOT / "config.yaml"
+    with cfg_file.open("r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    paths_cfg = cfg.get("paths", {})
+    for key, rel in paths_cfg.items():
+        p = ROOT / rel
+        p.mkdir(parents=True, exist_ok=True)
+        paths_cfg[key] = p
+    cfg["paths"] = paths_cfg
+    return cfg
+
+
+cfg = load_config()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ runner = CliRunner()
 def test_version_option():
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
-    assert "0.1.0" in result.stdout
+    assert "1.0.0" in result.stdout
 
 
 def test_full_calls_ensure_pandoc(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import wiki_documental.config as config
+
+
+def test_load_config_creates_directories(tmp_path, monkeypatch):
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "src/wiki_documental").mkdir(parents=True)
+    config_yaml = (
+        "paths:\n"
+        "  originals: 'inputs/_originals'\n"
+        "  work: 'work'\n"
+        "  wiki: 'wiki'\n"
+        "  tmp: 'work/tmp'\n"
+        "\n"
+        "options:\n"
+        "  ocr: false\n"
+        "  cutoff_similarity: 0.5\n"
+    )
+    (root / "config.yaml").write_text(config_yaml)
+
+    fake_file = root / "src/wiki_documental/config.py"
+    fake_file.write_text("")
+    monkeypatch.setattr(config, "__file__", str(fake_file))
+
+    cfg = config.load_config()
+    assert isinstance(cfg["paths"]["originals"], Path)
+    for path in cfg["paths"].values():
+        assert path.exists()


### PR DESCRIPTION
## Summary
- add config.yaml with directories and options
- load configuration from `config.yaml` at startup and ensure directories exist
- expose configuration via `wiki_documental.cfg`
- bump CLI version to 1.0.0
- update tests and add new config loader test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a29a1bbb08333860b52352a40c9c9