### PR TITLE
TASK-007 – Normalizador de estilos DOCX y comando CLI

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -1,7 +1,10 @@
 import typer
+from pathlib import Path
 from rich.console import Console
 
 from . import ensure_pandoc
+from .config import cfg
+from .processing.normalize_docx import normalize_styles
 
 app = typer.Typer(add_completion=False, add_help_option=True)
 
@@ -45,3 +48,13 @@ def full() -> None:
 def reset() -> None:
     """Reset wiki state (placeholder)."""
     typer.echo("Running reset placeholder")
+
+
+@app.command()
+def normalize(file: Path) -> None:
+    """Normalize styles in a DOCX file."""
+    dest_dir = cfg["paths"]["work"] / "normalized"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    out_file = dest_dir / file.name
+    normalize_styles(file, out_file)
+    typer.echo(f"Normalized DOCX saved to {out_file}")

--- a/src/wiki_documental/processing/normalize_docx.py
+++ b/src/wiki_documental/processing/normalize_docx.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from docx import Document
+
+
+def normalize_styles(doc_path: Path, out_path: Path) -> None:
+    """Normalize visual styles to structured heading styles in a DOCX file."""
+    document = Document(doc_path)
+    for paragraph in document.paragraphs:
+        for run in paragraph.runs:
+            size = run.font.size
+            bold = run.bold
+            if bold and size and size.pt >= 14:
+                paragraph.style = "Heading 1"
+                break
+            if bold and size and size.pt >= 12:
+                paragraph.style = "Heading 2"
+                break
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    document.save(out_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 import builtins
+from docx import Document
+from docx.shared import Pt
 
 from typer.testing import CliRunner
 
@@ -24,3 +26,20 @@ def test_full_calls_ensure_pandoc(monkeypatch):
     assert result.exit_code == 0
     assert called["value"]
     assert "Running full placeholder" in result.stdout
+
+
+def test_normalize_command(tmp_path, monkeypatch):
+    sample = tmp_path / "sample.docx"
+    doc = Document()
+    run = doc.add_paragraph().add_run("Title")
+    run.bold = True
+    run.font.size = Pt(16)
+    doc.add_paragraph("Text")
+    doc.save(sample)
+
+    monkeypatch.setattr(
+        "wiki_documental.cli.cfg", {"paths": {"work": tmp_path}}
+    )
+    result = runner.invoke(app, ["normalize", str(sample)])
+    assert result.exit_code == 0
+    assert (tmp_path / "normalized" / sample.name).exists()

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -7,9 +7,15 @@ from wiki_documental.processing.normalize_docx import normalize_styles
 def test_normalize_styles(tmp_path):
     sample = tmp_path / "sample.docx"
     doc = Document()
-    run = doc.add_paragraph().add_run("Title")
-    run.bold = True
-    run.font.size = Pt(16)
+
+    run_h1 = doc.add_paragraph().add_run("Title H1")
+    run_h1.bold = True
+    run_h1.font.size = Pt(16)
+
+    run_h2 = doc.add_paragraph().add_run("Title H2")
+    run_h2.bold = True
+    run_h2.font.size = Pt(12)
+
     doc.add_paragraph("Body text")
     doc.save(sample)
 
@@ -18,4 +24,5 @@ def test_normalize_styles(tmp_path):
 
     doc = Document(out)
     assert doc.paragraphs[0].style.name == "Heading 1"
-    assert doc.paragraphs[1].style.name == "Normal"
+    assert doc.paragraphs[1].style.name == "Heading 2"
+    assert doc.paragraphs[2].style.name == "Normal"

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,21 @@
+from docx import Document
+from docx.shared import Pt
+
+from wiki_documental.processing.normalize_docx import normalize_styles
+
+
+def test_normalize_styles(tmp_path):
+    sample = tmp_path / "sample.docx"
+    doc = Document()
+    run = doc.add_paragraph().add_run("Title")
+    run.bold = True
+    run.font.size = Pt(16)
+    doc.add_paragraph("Body text")
+    doc.save(sample)
+
+    out = tmp_path / "out.docx"
+    normalize_styles(sample, out)
+
+    doc = Document(out)
+    assert doc.paragraphs[0].style.name == "Heading 1"
+    assert doc.paragraphs[1].style.name == "Normal"


### PR DESCRIPTION
## Summary
- add a normalizer to convert bold text into heading styles
- integrate `wiki normalize` CLI command
- provide unit tests that generate sample DOCX dynamically
- remove binary fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2c8a131c833384833474d2543f53