### PR TITLE
TASK-008 – Conversión DOCX→Markdown y comando CLI

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from . import ensure_pandoc
 from .config import cfg
 from .processing.normalize_docx import normalize_styles
+from .processing.docx_to_md import convert_docx_to_md
 
 app = typer.Typer(add_completion=False, add_help_option=True)
 
@@ -58,3 +59,13 @@ def normalize(file: Path) -> None:
     out_file = dest_dir / file.name
     normalize_styles(file, out_file)
     typer.echo(f"Normalized DOCX saved to {out_file}")
+
+
+@app.command()
+def convert(file: Path) -> None:
+    """Convert DOCX to Markdown using Pandoc."""
+    dest_dir = cfg["paths"]["work"] / "md_raw"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    out_file = dest_dir / f"{file.stem}.md"
+    convert_docx_to_md(file, out_file)
+    typer.echo(f"Converted markdown saved to {out_file}")

--- a/src/wiki_documental/processing/docx_to_md.py
+++ b/src/wiki_documental/processing/docx_to_md.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import subprocess
+from wiki_documental.utils.system import ensure_pandoc
+
+
+def convert_docx_to_md(docx_path: Path, md_path: Path) -> None:
+    ensure_pandoc()
+    cmd = ["pandoc", str(docx_path), "-f", "docx", "-t", "gfm", "-o", str(md_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"Pandoc error: {result.stderr}")

--- a/tests/test_docx_to_md.py
+++ b/tests/test_docx_to_md.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from docx import Document
+from wiki_documental.processing.docx_to_md import convert_docx_to_md
+
+
+def _create_sample_docx(path: Path, text: str) -> None:
+    doc = Document()
+    doc.add_paragraph(text)
+    doc.save(path)
+
+
+def test_convert_docx_to_md(tmp_path, monkeypatch):
+    docx_file = tmp_path / "sample.docx"
+    md_file = tmp_path / "sample.md"
+    _create_sample_docx(docx_file, "Hello")
+
+    def fake_run(cmd, capture_output=True, text=True):
+        md_file.write_text("Hello")
+        class Result:
+            returncode = 0
+            stderr = ""
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None
+    )
+    convert_docx_to_md(docx_file, md_file)
+    assert md_file.exists()
+    assert md_file.read_text() == "Hello"


### PR DESCRIPTION
## Summary
- add `convert_docx_to_md` using Pandoc
- expose `wiki convert` command
- test docx to markdown conversion with mocked Pandoc

Pandoc must be installed for the CLI command. Tests mock `subprocess.run` so no real Pandoc call is required.

------
https://chatgpt.com/codex/tasks/task_e_684a32675b488333965a36c2230d1cd9