### PR TITLE
TASK-009 – Generador de mapa de encabezados e índice

### DIFF
--- a/src/wiki_documental/processing/headings_map.py
+++ b/src/wiki_documental/processing/headings_map.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Dict
+
+import yaml
+from slugify import slugify
+
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+
+
+def build_headings_map(md_folder: Path) -> List[Dict[str, str | int]]:
+    """Devuelve lista de dicts: [{'level': 1, 'title': '...', 'slug': '...'}, ...]"""
+    map_data: List[Dict[str, str | int]] = []
+    for md_file in md_folder.rglob("*.md"):
+        with md_file.open("r", encoding="utf-8") as f:
+            for line in f:
+                m = HEADING_RE.match(line.strip())
+                if m:
+                    level = len(m.group(1))
+                    title = m.group(2).strip()
+                    map_data.append(
+                        {
+                            "level": level,
+                            "title": title,
+                            "slug": slugify(title),
+                        }
+                    )
+    return map_data
+
+
+def save_map_yaml(map_data: List[Dict[str, str | int]], path: Path) -> None:
+    """Save map data to YAML file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(map_data, f, allow_unicode=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,3 +43,18 @@ def test_normalize_command(tmp_path, monkeypatch):
     result = runner.invoke(app, ["normalize", str(sample)])
     assert result.exit_code == 0
     assert (tmp_path / "normalized" / sample.name).exists()
+
+import yaml
+
+
+def test_map_command(tmp_path, monkeypatch):
+    md_folder = tmp_path / "md_raw"
+    md_folder.mkdir()
+    (md_folder / "sample.md").write_text("# Title\n")
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": tmp_path}})
+    result = runner.invoke(app, ["map"])
+    assert result.exit_code == 0
+    map_file = tmp_path / "map.yaml"
+    assert map_file.exists()
+    data = yaml.safe_load(map_file.read_text())
+    assert data[0]["slug"] == "title"

--- a/tests/test_headings_map.py
+++ b/tests/test_headings_map.py
@@ -1,0 +1,14 @@
+from wiki_documental.processing.headings_map import build_headings_map
+
+
+def test_build_headings_map(tmp_path):
+    md_folder = tmp_path / "md_raw"
+    md_folder.mkdir()
+    md_file = md_folder / "sample.md"
+    md_file.write_text("# H1\n## H2\n### H3\n")
+    result = build_headings_map(md_folder)
+    assert result == [
+        {"level": 1, "title": "H1", "slug": "h1"},
+        {"level": 2, "title": "H2", "slug": "h2"},
+        {"level": 3, "title": "H3", "slug": "h3"},
+    ]


### PR DESCRIPTION
## Summary
- add `headings_map` module for extracting markdown headings
- extend CLI with `map` and `index` commands
- generate map.yaml and index.yaml in the work directory
- test headings map generation and new CLI command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a33ff163c8333ab101d49a5c687b3