### PR TITLE
TASK-010 – Verificador pre-ingesta map vs index

### DIFF
--- a/src/wiki_documental/processing/verify_pre_ingest.py
+++ b/src/wiki_documental/processing/verify_pre_ingest.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+
+def _load_map_slugs(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or []
+    return {item.get("slug") for item in data if item.get("slug")}
+
+
+def _load_index_slugs(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or []
+    slugs: set[str] = set()
+    for entry in data:
+        slug = entry.get("slug")
+        if slug:
+            slugs.add(slug)
+        for child in entry.get("children", []):
+            child_slug = child.get("slug")
+            if child_slug:
+                slugs.add(child_slug)
+    return slugs
+
+
+def compare_map_index(map_path: Path, index_path: Path) -> Dict[str, List[str]]:
+    """Return differences between map and index slugs."""
+    map_slugs = _load_map_slugs(map_path)
+    index_slugs = _load_index_slugs(index_path)
+    return {
+        "missing_in_index": sorted(map_slugs - index_slugs),
+        "missing_in_map": sorted(index_slugs - map_slugs),
+    }

--- a/tests/test_verify_pre_ingest.py
+++ b/tests/test_verify_pre_ingest.py
@@ -1,0 +1,55 @@
+import yaml
+from typer.testing import CliRunner
+
+from wiki_documental.cli import app
+from wiki_documental.processing.verify_pre_ingest import compare_map_index
+
+runner = CliRunner()
+
+
+def test_compare_map_index(tmp_path):
+    map_data = [
+        {"level": 1, "title": "H1", "slug": "h1"},
+        {"level": 2, "title": "H1.1", "slug": "h1-1"},
+    ]
+    index_data = [
+        {"title": "H1", "slug": "h1", "children": [
+            {"level": 2, "title": "H1.1", "slug": "h1-1"}
+        ]}
+    ]
+    map_file = tmp_path / "map.yaml"
+    index_file = tmp_path / "index.yaml"
+    map_file.write_text(yaml.safe_dump(map_data, allow_unicode=True))
+    index_file.write_text(yaml.safe_dump(index_data, allow_unicode=True))
+
+    diffs = compare_map_index(map_file, index_file)
+    assert diffs == {"missing_in_index": [], "missing_in_map": []}
+
+
+
+def test_verify_cli(tmp_path, monkeypatch):
+    map_data = [{"level": 1, "title": "A", "slug": "a"}]
+    index_data = [{"title": "A", "slug": "a", "children": []}]
+
+    work = tmp_path
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True))
+    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True))
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
+
+    result = runner.invoke(app, ["verify"])
+    assert result.exit_code == 0
+
+
+
+def test_verify_cli_with_diffs(tmp_path, monkeypatch):
+    map_data = [{"level": 1, "title": "A", "slug": "a"}]
+    index_data = [{"title": "B", "slug": "b", "children": []}]
+
+    work = tmp_path
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True))
+    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True))
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
+
+    result = runner.invoke(app, ["verify"])
+    assert result.exit_code == 1
+


### PR DESCRIPTION
## Summary
- add pre-ingest validator `compare_map_index`
- expose `wiki verify` CLI command using Rich tables
- test map/index comparison and CLI behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a35873b748333b378cc246a663877