### PR TITLE
TASK-011 – Índice jerárquico completo + fixes de tipado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # Wiki Documental
 
 This project provides utilities for organizing and extracting information from wiki-like content.
+
+## CLI usage
+
+### `wiki index`
+
+Generates `index.yaml` from the headings map. By default the index is hierarchical and contains an `id` field representing the heading position (e.g. `1`, `1.1`, `1.1.1`).
+
+Options:
+
+- `--overwrite` – replace an existing `index.yaml` file.
+- `--flat` – create a two-level index as in previous versions.
+
+Example hierarchical entry:
+
+```yaml
+- id: "1"
+  title: Introduction
+  slug: introduction
+  children:
+    - id: "1.1"
+      title: Details
+      slug: details
+      children: []
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ pdf = ["pdfminer.six", "pdf2image", "pytesseract"]
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
 pytest-cov = "^5.0"
+types-python-slugify = "^8.0"
+types-pytest = "^8.0"
 
 [tool.poetry.scripts]
 wiki = "wiki_documental.cli:app"

--- a/src/wiki_documental/processing/index_builder.py
+++ b/src/wiki_documental/processing/index_builder.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+
+def build_index_from_map(map_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Generate hierarchical index data from headings map."""
+    index: List[Dict[str, Any]] = []
+    stack: List[tuple[int, Dict[str, Any]]] = []
+    counters: dict[int, int] = {}
+
+    for item in map_data:
+        level = int(item.get("level", 1))
+        counters[level] = counters.get(level, 0) + 1
+        for l in list(counters.keys()):
+            if l > level:
+                del counters[l]
+        id_parts = [str(counters[i]) for i in range(1, level + 1) if i in counters]
+        entry = {
+            "id": ".".join(id_parts),
+            "title": item.get("title"),
+            "slug": item.get("slug"),
+            "children": [],
+        }
+        while stack and stack[-1][0] >= level:
+            stack.pop()
+        if stack:
+            stack[-1][1]["children"].append(entry)
+        else:
+            index.append(entry)
+        stack.append((level, entry))
+
+    return index

--- a/src/wiki_documental/processing/normalize_docx.py
+++ b/src/wiki_documental/processing/normalize_docx.py
@@ -7,7 +7,7 @@ from docx import Document
 
 def normalize_styles(doc_path: Path, out_path: Path) -> None:
     """Normalize visual styles to structured heading styles in a DOCX file."""
-    document = Document(doc_path)
+    document = Document(str(doc_path))
     for paragraph in document.paragraphs:
         for run in paragraph.runs:
             size = run.font.size
@@ -19,4 +19,4 @@ def normalize_styles(doc_path: Path, out_path: Path) -> None:
                 paragraph.style = "Heading 2"
                 break
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    document.save(out_path)
+    document.save(str(out_path))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,3 +58,21 @@ def test_map_command(tmp_path, monkeypatch):
     assert map_file.exists()
     data = yaml.safe_load(map_file.read_text())
     assert data[0]["slug"] == "title"
+
+
+def test_index_overwrite(tmp_path, monkeypatch):
+    map_data = [
+        {"level": 1, "title": "A", "slug": "a"},
+        {"level": 2, "title": "B", "slug": "b"},
+        {"level": 3, "title": "C", "slug": "c"},
+    ]
+    work = tmp_path
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True))
+    (work / "index.yaml").write_text("old")
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
+
+    result = runner.invoke(app, ["index", "--overwrite"])
+    assert result.exit_code == 0
+    data = yaml.safe_load((work / "index.yaml").read_text())
+    assert data[0]["id"] == "1"
+    assert data[0]["children"][0]["children"][0]["id"] == "1.1.1"

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -1,0 +1,15 @@
+from wiki_documental.processing.index_builder import build_index_from_map
+
+
+def test_build_index_from_map():
+    map_data = [
+        {"level": 1, "title": "H1", "slug": "h1"},
+        {"level": 2, "title": "H1.1", "slug": "h1-1"},
+        {"level": 3, "title": "H1.1.1", "slug": "h1-1-1"},
+        {"level": 1, "title": "H2", "slug": "h2"},
+    ]
+    result = build_index_from_map(map_data)
+    assert result[0]["id"] == "1"
+    assert result[0]["children"][0]["id"] == "1.1"
+    assert result[0]["children"][0]["children"][0]["id"] == "1.1.1"
+    assert result[1]["id"] == "2"


### PR DESCRIPTION
## Summary
- add stub typings to development dependencies
- improve DOCX normalization typings
- build hierarchical index structures
- update CLI to build hierarchical index with `--flat` and `--overwrite`
- recursively load slugs for index verification
- update docs
- add tests for index builder and CLI overwrite

## Testing
- `pip install .`
- `pip install python-docx PyYAML rich python-slugify tqdm typer`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3f9178ac8333bb829c54ab0b1de7