### PR TITLE
TASK-012 – Fragmentación de Markdown e ingesta en wiki/

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -7,6 +7,7 @@ from .config import cfg
 from .processing.normalize_docx import normalize_styles
 from .processing.docx_to_md import convert_docx_to_md
 from .processing.headings_map import build_headings_map, save_map_yaml
+from .processing.ingest import ingest_content
 import yaml
 
 app = typer.Typer(add_completion=False, add_help_option=True)
@@ -147,4 +148,14 @@ def verify(force: bool = typer.Option(False, "--force", "-f", help="Continue eve
     console.print(table)
     if not force:
         raise typer.Exit(code=1)
+
+
+@app.command()
+def ingest(file: Path) -> None:
+    """Fragment a consolidated Markdown file into wiki sections."""
+    index_path = cfg["paths"]["work"] / "index.yaml"
+    wiki_dir = cfg["paths"]["wiki"]
+    cutoff = float(cfg.get("options", {}).get("cutoff_similarity", 0.5))
+    ingest_content(file, index_path, wiki_dir, cutoff=cutoff)
+    typer.echo("Content ingested")
 

--- a/src/wiki_documental/processing/ingest.py
+++ b/src/wiki_documental/processing/ingest.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+
+
+def _flatten_index(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    flat: List[Dict[str, Any]] = []
+    for entry in entries:
+        flat.append({
+            "id": entry.get("id"),
+            "title": entry.get("title"),
+            "slug": entry.get("slug"),
+        })
+        children = entry.get("children") or []
+        flat.extend(_flatten_index(children))
+    return flat
+
+
+def _parse_sections(md_path: Path) -> List[tuple[str, List[str]]]:
+    sections: List[tuple[str, List[str]]] = []
+    with md_path.open("r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    current_title: str | None = None
+    buffer: List[str] = []
+    intro: List[str] = []
+    for line in lines:
+        m = HEADING_RE.match(line)
+        if m:
+            if current_title is None and intro:
+                sections.append(("__intro__", intro))
+            if current_title is not None:
+                sections.append((current_title, buffer))
+            current_title = m.group(2).strip()
+            buffer = [line]
+        else:
+            if current_title is None:
+                intro.append(line)
+            else:
+                buffer.append(line)
+    if current_title is not None:
+        sections.append((current_title, buffer))
+    elif intro:
+        sections.append(("__intro__", intro))
+    return sections
+
+
+def ingest_content(md_path: Path, index_path: Path, out_dir: Path, cutoff: float = 0.5) -> None:
+    """Fragment markdown file according to index.yaml and store pieces."""
+    with index_path.open("r", encoding="utf-8") as f:
+        index_data = yaml.safe_load(f) or []
+    entries = _flatten_index(index_data)
+
+    sections = _parse_sections(md_path)
+
+    content_map: Dict[str, List[str]] = {e["slug"]: [] for e in entries}
+    unclassified: List[str] = []
+
+    for title, lines in sections:
+        if title == "__intro__":
+            unclassified.extend(lines)
+            continue
+        best_ratio = 0.0
+        best_slug: str | None = None
+        for entry in entries:
+            ratio = SequenceMatcher(None, title.lower(), str(entry["title"]).lower()).ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best_slug = entry["slug"]
+        if best_slug is not None and best_ratio >= cutoff:
+            content_map[best_slug].extend(lines)
+        else:
+            unclassified.extend(lines)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    created = datetime.utcnow().isoformat()
+    header = f"---\nsource: {md_path.name}\ncreated: {created}\n---\n\n"
+
+    for entry in entries:
+        slug = entry["slug"]
+        if not slug:
+            continue
+        text = "".join(content_map.get(slug, []))
+        if not text.strip():
+            continue
+        prefix = str(entry.get("id", "")).replace(".", "-")
+        path = out_dir / f"{prefix}_{slug}.md"
+        with path.open("w", encoding="utf-8") as f:
+            f.write(header)
+            f.write(text)
+
+    if unclassified:
+        with (out_dir / "99_unclassified.md").open("w", encoding="utf-8") as f:
+            f.write(header)
+            f.writelines(unclassified)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import yaml
+
+from wiki_documental.processing.ingest import ingest_content
+
+
+def test_ingest_content(tmp_path):
+    md = tmp_path / "full.md"
+    md.write_text("# X\ntext1\n## Y\ntext2\n# Z\ntext3\n")
+
+    index = [
+        {"id": "1", "title": "X", "slug": "x", "children": []},
+        {"id": "2", "title": "Z", "slug": "z", "children": []},
+    ]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True))
+
+    out_dir = tmp_path / "wiki"
+    ingest_content(md, index_path, out_dir, cutoff=0.5)
+
+    assert (out_dir / "1_x.md").exists()
+    assert (out_dir / "2_z.md").exists()
+    assert (out_dir / "99_unclassified.md").exists()
+


### PR DESCRIPTION
## Summary
- implement ingest_content for fragmenting markdown by index
- expose ingest command in CLI
- test ingest functionality

## Testing
- `pip install -q typer PyYAML python-slugify rich python-docx pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a466277cc8333bfcc500a5a1effb6