### PR TITLE
TASK-013 – Sidebar Docsify + mejora de ingesta con niveles 2–3

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -8,6 +8,7 @@ from .processing.normalize_docx import normalize_styles
 from .processing.docx_to_md import convert_docx_to_md
 from .processing.headings_map import build_headings_map, save_map_yaml
 from .processing.ingest import ingest_content
+from .processing.sidebar import build_sidebar
 import yaml
 
 app = typer.Typer(add_completion=False, add_help_option=True)
@@ -158,4 +159,13 @@ def ingest(file: Path) -> None:
     cutoff = float(cfg.get("options", {}).get("cutoff_similarity", 0.5))
     ingest_content(file, index_path, wiki_dir, cutoff=cutoff)
     typer.echo("Content ingested")
+
+
+@app.command()
+def sidebar() -> None:
+    """Generate _sidebar.md for Docsify."""
+    index_path = cfg["paths"]["work"] / "index.yaml"
+    output_path = cfg["paths"]["wiki"] / "_sidebar.md"
+    build_sidebar(index_path, output_path)
+    typer.echo("Sidebar generated")
 

--- a/src/wiki_documental/processing/ingest.py
+++ b/src/wiki_documental/processing/ingest.py
@@ -25,6 +25,7 @@ def _flatten_index(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 def _parse_sections(md_path: Path) -> List[tuple[str, List[str]]]:
+    """Return list of sections split by level 1 headings."""
     sections: List[tuple[str, List[str]]] = []
     with md_path.open("r", encoding="utf-8") as f:
         lines = f.readlines()
@@ -35,12 +36,19 @@ def _parse_sections(md_path: Path) -> List[tuple[str, List[str]]]:
     for line in lines:
         m = HEADING_RE.match(line)
         if m:
-            if current_title is None and intro:
-                sections.append(("__intro__", intro))
-            if current_title is not None:
-                sections.append((current_title, buffer))
-            current_title = m.group(2).strip()
-            buffer = [line]
+            level = len(m.group(1))
+            if level == 1:
+                if current_title is None and intro:
+                    sections.append(("__intro__", intro))
+                if current_title is not None:
+                    sections.append((current_title, buffer))
+                current_title = m.group(2).strip()
+                buffer = [line]
+            else:
+                if current_title is None:
+                    intro.append(line)
+                else:
+                    buffer.append(line)
         else:
             if current_title is None:
                 intro.append(line)

--- a/src/wiki_documental/processing/sidebar.py
+++ b/src/wiki_documental/processing/sidebar.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+import yaml
+
+
+def build_sidebar(index_path: Path, output_path: Path) -> None:
+    """Crea _sidebar.md jerárquico a partir de index.yaml."""
+
+    with index_path.open("r", encoding="utf-8") as f:
+        index_data: List[Dict[str, object]] = yaml.safe_load(f) or []
+
+    lines: List[str] = ["* [Inicio](README.md)\n"]
+
+    def add_entries(entries: List[Dict[str, object]], level: int) -> None:
+        indent = "  " * level
+        for entry in entries:
+            slug = entry.get("slug")
+            title = entry.get("title")
+            identifier = str(entry.get("id", "")).replace(".", "-")
+            file_name = f"{identifier}_{slug}.md"
+            lines.append(f"{indent}* [{title}]({file_name})\n")
+            children = entry.get("children") or []
+            add_entries(children, level + 1)
+
+    add_entries(index_data, 0)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        f.writelines(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,3 +76,21 @@ def test_index_overwrite(tmp_path, monkeypatch):
     data = yaml.safe_load((work / "index.yaml").read_text())
     assert data[0]["id"] == "1"
     assert data[0]["children"][0]["children"][0]["id"] == "1.1.1"
+
+
+def test_sidebar_command(tmp_path, monkeypatch):
+    index = [
+        {"id": "1", "title": "A", "slug": "a", "children": []}
+    ]
+    work = tmp_path
+    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True))
+    paths = {"work": work, "wiki": work}
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
+
+    result = runner.invoke(app, ["sidebar"])
+    assert result.exit_code == 0
+    sidebar = work / "_sidebar.md"
+    assert sidebar.exists()
+    content = sidebar.read_text().splitlines()
+    assert content[1] == "* [A](1_a.md)"
+

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -6,7 +6,7 @@ from wiki_documental.processing.ingest import ingest_content
 
 def test_ingest_content(tmp_path):
     md = tmp_path / "full.md"
-    md.write_text("# X\ntext1\n## Y\ntext2\n# Z\ntext3\n")
+    md.write_text("# X\ntext1\n## Y\ntext2\n### Zeta\ntext3\n# Z\ntext4\n")
 
     index = [
         {"id": "1", "title": "X", "slug": "x", "children": []},
@@ -18,7 +18,12 @@ def test_ingest_content(tmp_path):
     out_dir = tmp_path / "wiki"
     ingest_content(md, index_path, out_dir, cutoff=0.5)
 
-    assert (out_dir / "1_x.md").exists()
-    assert (out_dir / "2_z.md").exists()
-    assert (out_dir / "99_unclassified.md").exists()
+    first = out_dir / "1_x.md"
+    second = out_dir / "2_z.md"
+    assert first.exists()
+    assert second.exists()
+    assert not (out_dir / "99_unclassified.md").exists()
+    content = first.read_text()
+    assert "## Y" in content
+    assert "### Zeta" in content
 

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -1,0 +1,37 @@
+import yaml
+from wiki_documental.processing.sidebar import build_sidebar
+
+
+def test_build_sidebar(tmp_path):
+    index = [
+        {
+            "id": "1",
+            "title": "Contexto",
+            "slug": "contexto",
+            "children": [
+                {
+                    "id": "1.1",
+                    "title": "Funcion",
+                    "slug": "funcion",
+                    "children": [
+                        {
+                            "id": "1.1.1",
+                            "title": "Detalles",
+                            "slug": "detalles",
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True))
+    out_file = tmp_path / "_sidebar.md"
+    build_sidebar(index_path, out_file)
+
+    lines = out_file.read_text().splitlines()
+    assert lines[0] == "* [Inicio](README.md)"
+    assert lines[1] == "* [Contexto](1_contexto.md)"
+    assert lines[2] == "  * [Funcion](1-1_funcion.md)"
+    assert lines[3] == "    * [Detalles](1-1-1_detalles.md)"


### PR DESCRIPTION
## Summary
- add sidebar builder module
- include new `sidebar` CLI command
- improve ingestion to keep subheaders inside each section
- tests for sidebar generation, CLI and ingestion

## Testing
- `pip install -e .`
- `pip install typer PyYAML`
- `pip install python-slugify`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a485e549c8333b811dfe71e6404d4