### PR TITLE
Expose version in package

### DIFF
--- a/src/wiki_documental/__init__.py
+++ b/src/wiki_documental/__init__.py
@@ -1,3 +1,11 @@
+
+from importlib.metadata import PackageNotFoundError, version
+
 from .utils.system import ensure_pandoc
 from .config import cfg  # noqa: F401
+
+try:  # pragma: no cover - best effort when package isn't installed
+    __version__ = version("wiki_documental")
+except PackageNotFoundError:  # pragma: no cover - fallback for local use
+    __version__ = "0.0.0"
 

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -2,7 +2,7 @@ import typer
 from pathlib import Path
 from rich.console import Console
 
-from . import ensure_pandoc
+from . import ensure_pandoc, __version__
 from .config import cfg
 from .processing.normalize_docx import normalize_styles
 from .processing.docx_to_md import convert_docx_to_md
@@ -12,8 +12,6 @@ from .processing.sidebar import build_sidebar
 import yaml
 
 app = typer.Typer(add_completion=False, add_help_option=True)
-
-__version__ = "1.0.0"
 
 
 def _version_callback(value: bool) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from docx.shared import Pt
 
 from typer.testing import CliRunner
 
+import wiki_documental
 from wiki_documental.cli import app
 
 runner = CliRunner()
@@ -12,7 +13,7 @@ runner = CliRunner()
 def test_version_option():
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
-    assert "1.0.0" in result.stdout
+    assert wiki_documental.__version__ in result.stdout
 
 
 def test_full_calls_ensure_pandoc(monkeypatch):


### PR DESCRIPTION
## Summary
- expose `__version__` in `wiki_documental` package using `importlib.metadata`
- reference package version from CLI
- expect CLI tests to match dynamic `__version__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a949d304c83339ba0c32013f971fe