### PR TITLE
TASK-SYS-002 – Corrección de codificación global UTF-8 en lectura/escritura

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -84,7 +84,7 @@ def full() -> None:
     tmp_full = tmp_dir / "tmp_full.md"
     with tmp_full.open("w", encoding="utf-8") as out:
         for md in sorted(md_raw_dir.glob("*.md")):
-            out.write(md.read_text())
+            out.write(md.read_text(encoding="utf-8"))
             out.write("\n\n")
 
     map_path = cfg["paths"]["work"] / "map.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def test_full_calls_ensure_pandoc(monkeypatch, tmp_path):
     doc.save(doc_path)
 
     def fake_run(cmd, capture_output=True, text=True):
-        Path(cmd[-1]).write_text("# Title\nText")
+        Path(cmd[-1]).write_text("# Title\nText", encoding="utf-8")
         class Result:
             returncode = 0
             stderr = ""
@@ -81,13 +81,13 @@ import yaml
 def test_map_command(tmp_path, monkeypatch):
     md_folder = tmp_path / "md_raw"
     md_folder.mkdir()
-    (md_folder / "sample.md").write_text("# Title\n")
+    (md_folder / "sample.md").write_text("# Title\n", encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": tmp_path}})
     result = runner.invoke(app, ["map"])
     assert result.exit_code == 0
     map_file = tmp_path / "map.yaml"
     assert map_file.exists()
-    data = yaml.safe_load(map_file.read_text())
+    data = yaml.safe_load(map_file.read_text(encoding="utf-8"))
     assert data[0]["slug"] == "title"
 
 
@@ -98,13 +98,13 @@ def test_index_overwrite(tmp_path, monkeypatch):
         {"level": 3, "title": "C", "slug": "c"},
     ]
     work = tmp_path
-    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True))
-    (work / "index.yaml").write_text("old")
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+    (work / "index.yaml").write_text("old", encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
 
     result = runner.invoke(app, ["index", "--overwrite"])
     assert result.exit_code == 0
-    data = yaml.safe_load((work / "index.yaml").read_text())
+    data = yaml.safe_load((work / "index.yaml").read_text(encoding="utf-8"))
     assert data[0]["id"] == "1"
     assert data[0]["children"][0]["children"][0]["id"] == "1.1.1"
 
@@ -114,7 +114,7 @@ def test_sidebar_command(tmp_path, monkeypatch):
         {"id": "1", "title": "A", "slug": "a", "children": []}
     ]
     work = tmp_path
-    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True))
+    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
 
@@ -122,6 +122,6 @@ def test_sidebar_command(tmp_path, monkeypatch):
     assert result.exit_code == 0
     sidebar = work / "_sidebar.md"
     assert sidebar.exists()
-    content = sidebar.read_text().splitlines()
+    content = sidebar.read_text(encoding="utf-8").splitlines()
     assert content[1] == "* [A](1_a.md)"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,10 +18,10 @@ def test_load_config_creates_directories(tmp_path, monkeypatch):
         "  ocr: false\n"
         "  cutoff_similarity: 0.5\n"
     )
-    (root / "config.yaml").write_text(config_yaml)
+    (root / "config.yaml").write_text(config_yaml, encoding="utf-8")
 
     fake_file = root / "src/wiki_documental/config.py"
-    fake_file.write_text("")
+    fake_file.write_text("", encoding="utf-8")
     monkeypatch.setattr(config, "__file__", str(fake_file))
 
     cfg = config.load_config()

--- a/tests/test_docx_to_md.py
+++ b/tests/test_docx_to_md.py
@@ -15,7 +15,7 @@ def test_convert_docx_to_md(tmp_path, monkeypatch):
     _create_sample_docx(docx_file, "Hello")
 
     def fake_run(cmd, capture_output=True, text=True):
-        md_file.write_text("Hello")
+        md_file.write_text("Hello", encoding="utf-8")
         class Result:
             returncode = 0
             stderr = ""
@@ -27,4 +27,4 @@ def test_convert_docx_to_md(tmp_path, monkeypatch):
     )
     convert_docx_to_md(docx_file, md_file)
     assert md_file.exists()
-    assert md_file.read_text() == "Hello"
+    assert md_file.read_text(encoding="utf-8") == "Hello"

--- a/tests/test_encoding_utf8.py
+++ b/tests/test_encoding_utf8.py
@@ -1,0 +1,17 @@
+import pytest
+from pathlib import Path
+
+def test_read_write_utf8(tmp_path):
+    text = "Título: ¿Qué tal? — ¡Bien! áéíóú ñ Ñ \u201cquotes\u201d"
+    md = tmp_path / "sample.md"
+    copy = tmp_path / "copy.md"
+
+    md.write_text(text, encoding="utf-8")
+
+    try:
+        content = md.read_text(encoding="utf-8")
+        copy.write_text(content, encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        pytest.fail(f"Unicode error: {exc}")
+
+    assert copy.read_text(encoding="utf-8") == text

--- a/tests/test_headings_map.py
+++ b/tests/test_headings_map.py
@@ -5,7 +5,7 @@ def test_build_headings_map(tmp_path):
     md_folder = tmp_path / "md_raw"
     md_folder.mkdir()
     md_file = md_folder / "sample.md"
-    md_file.write_text("# H1\n## H2\n### H3\n")
+    md_file.write_text("# H1\n## H2\n### H3\n", encoding="utf-8")
     result = build_headings_map(md_folder)
     assert result == [
         {"level": 1, "title": "H1", "slug": "h1"},

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -6,14 +6,14 @@ from wiki_documental.processing.ingest import ingest_content
 
 def test_ingest_content(tmp_path):
     md = tmp_path / "full.md"
-    md.write_text("# X\ntext1\n## Y\ntext2\n### Zeta\ntext3\n# Z\ntext4\n")
+    md.write_text("# X\ntext1\n## Y\ntext2\n### Zeta\ntext3\n# Z\ntext4\n", encoding="utf-8")
 
     index = [
         {"id": "1", "title": "X", "slug": "x", "children": []},
         {"id": "2", "title": "Z", "slug": "z", "children": []},
     ]
     index_path = tmp_path / "index.yaml"
-    index_path.write_text(yaml.safe_dump(index, allow_unicode=True))
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
 
     out_dir = tmp_path / "wiki"
     ingest_content(md, index_path, out_dir, cutoff=0.5)
@@ -23,7 +23,7 @@ def test_ingest_content(tmp_path):
     assert first.exists()
     assert second.exists()
     assert not (out_dir / "99_unclassified.md").exists()
-    content = first.read_text()
+    content = first.read_text(encoding="utf-8")
     assert "## Y" in content
     assert "### Zeta" in content
 

--- a/tests/test_pipeline_full.py
+++ b/tests/test_pipeline_full.py
@@ -28,7 +28,7 @@ def test_pipeline_full(tmp_path, monkeypatch):
 
     def fake_run(cmd, capture_output=True, text=True):
         md = Path(cmd[-1])
-        md.write_text("# Title\nBody")
+        md.write_text("# Title\nBody", encoding="utf-8")
         class R:
             returncode = 0
             stderr = ""

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -26,11 +26,11 @@ def test_build_sidebar(tmp_path):
         }
     ]
     index_path = tmp_path / "index.yaml"
-    index_path.write_text(yaml.safe_dump(index, allow_unicode=True))
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
     out_file = tmp_path / "_sidebar.md"
     build_sidebar(index_path, out_file)
 
-    lines = out_file.read_text().splitlines()
+    lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines[0] == "* [Inicio](README.md)"
     assert lines[1] == "* [Contexto](1_contexto.md)"
     assert lines[2] == "  * [Funcion](1-1_funcion.md)"

--- a/tests/test_verify_pre_ingest.py
+++ b/tests/test_verify_pre_ingest.py
@@ -19,8 +19,8 @@ def test_compare_map_index(tmp_path):
     ]
     map_file = tmp_path / "map.yaml"
     index_file = tmp_path / "index.yaml"
-    map_file.write_text(yaml.safe_dump(map_data, allow_unicode=True))
-    index_file.write_text(yaml.safe_dump(index_data, allow_unicode=True))
+    map_file.write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+    index_file.write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
 
     diffs = compare_map_index(map_file, index_file)
     assert diffs == {"missing_in_index": [], "missing_in_map": []}
@@ -32,8 +32,8 @@ def test_verify_cli(tmp_path, monkeypatch):
     index_data = [{"title": "A", "slug": "a", "children": []}]
 
     work = tmp_path
-    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True))
-    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True))
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
 
     result = runner.invoke(app, ["verify"])
@@ -46,8 +46,8 @@ def test_verify_cli_with_diffs(tmp_path, monkeypatch):
     index_data = [{"title": "B", "slug": "b", "children": []}]
 
     work = tmp_path
-    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True))
-    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True))
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
 
     result = runner.invoke(app, ["verify"])


### PR DESCRIPTION
## Summary
- force UTF-8 encoding when reading markdown in CLI
- update tests to specify UTF-8 encoding
- add UTF-8 encoding regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aac8cf82c833394d4b95174e16b8e