### PR TITLE
fix(docx): strip table of contents before processing

### DIFF
--- a/src/wiki_documental/processing/normalize_docx.py
+++ b/src/wiki_documental/processing/normalize_docx.py
@@ -5,9 +5,19 @@ from pathlib import Path
 from docx import Document
 
 
+def _remove_toc_paragraphs(document: Document) -> None:
+    """Delete paragraphs that belong to a table of contents."""
+    for paragraph in list(document.paragraphs):
+        style_name = paragraph.style.name if paragraph.style else ""
+        if style_name.startswith("TOC") or "......" in paragraph.text:
+            element = paragraph._element
+            element.getparent().remove(element)
+
+
 def normalize_styles(doc_path: Path, out_path: Path) -> None:
     """Normalize visual styles to structured heading styles in a DOCX file."""
     document = Document(str(doc_path))
+    _remove_toc_paragraphs(document)
     for paragraph in document.paragraphs:
         for run in paragraph.runs:
             size = run.font.size

--- a/tests/test_strip_toc.py
+++ b/tests/test_strip_toc.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from docx import Document
+from docx.shared import Pt
+from docx.enum.style import WD_STYLE_TYPE
+
+from wiki_documental.processing.normalize_docx import normalize_styles
+from wiki_documental.processing.docx_to_md import convert_docx_to_md
+
+
+def _fake_pandoc_run(cmd, capture_output=True, text=True):
+    docx = Path(cmd[1])
+    md = Path(cmd[-1])
+    doc = Document(docx)
+    lines = []
+    for p in doc.paragraphs:
+        name = p.style.name if p.style else ""
+        if name == "Heading 1":
+            lines.append(f"# {p.text}")
+        elif name == "Heading 2":
+            lines.append(f"## {p.text}")
+        else:
+            if p.text:
+                lines.append(p.text)
+    md.write_text("\n".join(lines), encoding="utf-8")
+    class R:
+        returncode = 0
+        stderr = ""
+    return R()
+
+
+def test_toc_not_in_md(tmp_path, monkeypatch):
+    docx_in = tmp_path / "in.docx"
+    docx_out = tmp_path / "out.docx"
+    md_file = tmp_path / "out.md"
+
+    doc = Document()
+    doc.add_paragraph("Contents", style="TOC Heading")
+    doc.styles.add_style("TOC 1", WD_STYLE_TYPE.PARAGRAPH)
+    doc.add_paragraph("Intro ...... 1", style="TOC 1")
+    run = doc.add_paragraph().add_run("Chapter 1")
+    run.bold = True
+    run.font.size = Pt(16)
+    doc.add_paragraph("Body text")
+    doc.save(docx_in)
+
+    normalize_styles(docx_in, docx_out)
+    monkeypatch.setattr("subprocess.run", _fake_pandoc_run)
+    monkeypatch.setattr(
+        "wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None
+    )
+    convert_docx_to_md(docx_out, md_file)
+    text = md_file.read_text(encoding="utf-8")
+    assert "......" not in text
+


### PR DESCRIPTION
## Summary
- remove TOC paragraphs before normalizing docx
- test that TOC lines don't appear in markdown output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acb07cb188333b55a826158ce98b5