### PR TITLE
feat(docx): support heading 3–4 style mapping

### DIFF
--- a/src/wiki_documental/processing/normalize_docx.py
+++ b/src/wiki_documental/processing/normalize_docx.py
@@ -4,19 +4,20 @@ from pathlib import Path
 
 from docx import Document
 
+from .style_map import HEADINGS_RULES
+
 
 def normalize_styles(doc_path: Path, out_path: Path) -> None:
     """Normalize visual styles to structured heading styles in a DOCX file."""
     document = Document(str(doc_path))
     for paragraph in document.paragraphs:
         for run in paragraph.runs:
-            size = run.font.size
-            bold = run.bold
-            if bold and size and size.pt >= 14:
-                paragraph.style = "Heading 1"
-                break
-            if bold and size and size.pt >= 12:
-                paragraph.style = "Heading 2"
-                break
+            for style, rule in HEADINGS_RULES.items():
+                if rule(run):
+                    paragraph.style = style
+                    break
+            else:
+                continue
+            break
     out_path.parent.mkdir(parents=True, exist_ok=True)
     document.save(str(out_path))

--- a/src/wiki_documental/processing/style_map.py
+++ b/src/wiki_documental/processing/style_map.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Callable
+from docx.text.run import Run
+
+# Mapping of heading styles to detection rules
+HEADINGS_RULES: dict[str, Callable[[Run], bool]] = {
+    "Heading 1": lambda run: bool(run.bold) and run.font.size and run.font.size.pt >= 14,
+    "Heading 2": lambda run: bool(run.bold) and run.font.size and run.font.size.pt >= 12,
+    "Heading 3": lambda run: bool(run.bold) and run.font.size and run.font.size.pt >= 10,
+    "Heading 4": lambda run: bool(run.bold) and bool(run.italic),
+}

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -16,6 +16,14 @@ def test_normalize_styles(tmp_path):
     run_h2.bold = True
     run_h2.font.size = Pt(12)
 
+    run_h3 = doc.add_paragraph().add_run("Title H3")
+    run_h3.bold = True
+    run_h3.font.size = Pt(10)
+
+    run_h4 = doc.add_paragraph().add_run("Title H4")
+    run_h4.bold = True
+    run_h4.italic = True
+
     doc.add_paragraph("Body text")
     doc.save(sample)
 
@@ -25,4 +33,6 @@ def test_normalize_styles(tmp_path):
     doc = Document(out)
     assert doc.paragraphs[0].style.name == "Heading 1"
     assert doc.paragraphs[1].style.name == "Heading 2"
-    assert doc.paragraphs[2].style.name == "Normal"
+    assert doc.paragraphs[2].style.name == "Heading 3"
+    assert doc.paragraphs[3].style.name == "Heading 4"
+    assert doc.paragraphs[4].style.name == "Normal"


### PR DESCRIPTION
## Summary
- support Heading 3 and Heading 4 detection during DOCX normalization
- centralize mapping of heading style rules
- test new heading detection rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acb1b32ec8333b26490a6e49179d2