### PR TITLE
feat(slug): generate short safe slugs and update map

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,7 @@ def test_map_command(tmp_path, monkeypatch):
     assert map_file.exists()
     data = yaml.safe_load(map_file.read_text(encoding="utf-8"))
     assert data[0]["slug"] == "title"
+    assert data[0]["id"] == "1"
 
 
 def test_index_overwrite(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure slugify uses lowercase and max length
- store heading `id` alongside slug when generating `map.yaml`
- test CLI map command for new `id` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acb26f6a88333a8842b4c6b626431