### PR TITLE
feat(sidebar): support depth option and default to level 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ Split a consolidated Markdown file into sections defined in `index.yaml`. Each s
 ### `wiki sidebar`
 
 Generate a `_sidebar.md` file for Docsify based on `index.yaml`.
+
+Options:
+
+- `--depth` – maximum heading level to include in the sidebar (default `1`).

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -241,10 +241,14 @@ def ingest(file: Path) -> None:
 
 
 @app.command()
-def sidebar() -> None:
+def sidebar(
+    depth: int = typer.Option(
+        1, "--depth", "-d", help="Maximum heading level to include"
+    )
+) -> None:
     """Generate _sidebar.md for Docsify."""
     index_path = cfg["paths"]["work"] / "index.yaml"
     output_path = cfg["paths"]["wiki"] / "_sidebar.md"
-    build_sidebar(index_path, output_path)
+    build_sidebar(index_path, output_path, depth=depth)
     typer.echo("Sidebar generated")
 

--- a/src/wiki_documental/processing/sidebar.py
+++ b/src/wiki_documental/processing/sidebar.py
@@ -6,8 +6,19 @@ from typing import List, Dict
 import yaml
 
 
-def build_sidebar(index_path: Path, output_path: Path) -> None:
-    """Crea _sidebar.md jerárquico a partir de index.yaml."""
+def build_sidebar(index_path: Path, output_path: Path, depth: int = 1) -> None:
+    """Crea _sidebar.md jerárquico a partir de index.yaml.
+
+    Parameters
+    ----------
+    index_path : Path
+        Ruta al archivo ``index.yaml``.
+    output_path : Path
+        Ruta del ``_sidebar.md`` a generar.
+    depth : int, optional
+        Profundidad máxima de títulos a incluir. ``1`` solo agrega los
+        encabezados de primer nivel.
+    """
 
     with index_path.open("r", encoding="utf-8") as f:
         index_data: List[Dict[str, object]] = yaml.safe_load(f) or []
@@ -23,7 +34,8 @@ def build_sidebar(index_path: Path, output_path: Path) -> None:
             file_name = f"{identifier}_{slug}.md"
             lines.append(f"{indent}* [{title}]({file_name})\n")
             children = entry.get("children") or []
-            add_entries(children, level + 1)
+            if level + 1 < depth:
+                add_entries(children, level + 1)
 
     add_entries(index_data, 0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,5 +123,33 @@ def test_sidebar_command(tmp_path, monkeypatch):
     sidebar = work / "_sidebar.md"
     assert sidebar.exists()
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content[1] == "* [A](1_a.md)"
+    assert content == ["* [Inicio](README.md)", "* [A](1_a.md)"]
+
+
+def test_sidebar_command_depth(tmp_path, monkeypatch):
+    index = [
+        {
+            "id": "1",
+            "title": "A",
+            "slug": "a",
+            "children": [
+                {
+                    "id": "1.1",
+                    "title": "B",
+                    "slug": "b",
+                    "children": [],
+                }
+            ],
+        }
+    ]
+    work = tmp_path
+    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    paths = {"work": work, "wiki": work}
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
+
+    result = runner.invoke(app, ["sidebar", "--depth", "2"])
+    assert result.exit_code == 0
+    sidebar = work / "_sidebar.md"
+    content = sidebar.read_text(encoding="utf-8").splitlines()
+    assert content[2] == "  * [B](1-1_b.md)"
 

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -2,8 +2,8 @@ import yaml
 from wiki_documental.processing.sidebar import build_sidebar
 
 
-def test_build_sidebar(tmp_path):
-    index = [
+def _sample_index():
+    return [
         {
             "id": "1",
             "title": "Contexto",
@@ -25,10 +25,28 @@ def test_build_sidebar(tmp_path):
             ],
         }
     ]
+
+
+def test_build_sidebar_default_depth(tmp_path):
+    index = _sample_index()
     index_path = tmp_path / "index.yaml"
     index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
     out_file = tmp_path / "_sidebar.md"
     build_sidebar(index_path, out_file)
+
+    lines = out_file.read_text(encoding="utf-8").splitlines()
+    assert lines == [
+        "* [Inicio](README.md)",
+        "* [Contexto](1_contexto.md)",
+    ]
+
+
+def test_build_sidebar_depth_3(tmp_path):
+    index = _sample_index()
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    out_file = tmp_path / "_sidebar.md"
+    build_sidebar(index_path, out_file, depth=3)
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines[0] == "* [Inicio](README.md)"


### PR DESCRIPTION
## Summary
- add optional `depth` parameter to sidebar builder with default level 1
- expose `--depth` option in CLI `sidebar` command
- document new option in README
- update sidebar unit tests and CLI tests for depth

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acb320d1483338d9c48a80d8e845b