### PR TITLE
Add media extraction workflow

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -1,3 +1,4 @@
+import shutil
 import typer
 from pathlib import Path
 from rich.console import Console
@@ -72,10 +73,11 @@ def full() -> None:
             raise typer.Exit(code=1)
 
     console.print("[bold]Converting DOCX to Markdown...[/bold]")
+    media_dir = md_raw_dir / "media"
     for docx in track(norm_dir.glob("*.docx"), description="Convert"):
         out = md_raw_dir / f"{docx.stem}.md"
         try:
-            convert_docx_to_md(docx, out)
+            convert_docx_to_md(docx, out, media_dir)
         except Exception as exc:  # pragma: no cover - defensive
             console.print(f"Error converting {docx.name}: {exc}", style="red")
             raise typer.Exit(code=1)
@@ -125,6 +127,13 @@ def full() -> None:
     console.print("[bold]Generating sidebar...[/bold]")
     build_sidebar(index_path, wiki_dir / "_sidebar.md")
 
+    media_src = md_raw_dir / "media"
+    if media_src.exists():
+        dest = wiki_dir / "assets" / "media"
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(media_src, dest)
+
     console.print(f"\N{check mark} Wiki generada correctamente en: {wiki_dir / 'index.html'}")
 
 
@@ -150,7 +159,7 @@ def convert(file: Path) -> None:
     dest_dir = cfg["paths"]["work"] / "md_raw"
     dest_dir.mkdir(parents=True, exist_ok=True)
     out_file = dest_dir / f"{file.stem}.md"
-    convert_docx_to_md(file, out_file)
+    convert_docx_to_md(file, out_file, dest_dir / "media")
     typer.echo(f"Converted markdown saved to {out_file}")
 
 

--- a/src/wiki_documental/processing/docx_to_md.py
+++ b/src/wiki_documental/processing/docx_to_md.py
@@ -3,9 +3,16 @@ import subprocess
 from wiki_documental.utils.system import ensure_pandoc
 
 
-def convert_docx_to_md(docx_path: Path, md_path: Path) -> None:
+def convert_docx_to_md(docx_path: Path, md_path: Path, media_path: Path | None = None) -> None:
+    """Convert DOCX to Markdown optionally extracting media files."""
     ensure_pandoc()
-    cmd = ["pandoc", str(docx_path), "-f", "docx", "-t", "gfm", "-o", str(md_path)]
+    cmd = ["pandoc", str(docx_path), "-f", "docx", "-t", "gfm"]
+    if media_path is not None:
+        cmd.append(f"--extract-media={media_path}")
+    cmd.extend(["-o", str(md_path)])
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(f"Pandoc error: {result.stderr}")
+    text = md_path.read_text(encoding="utf-8")
+    text = text.replace("media/", "assets/media/")
+    md_path.write_text(text, encoding="utf-8")

--- a/tests/test_pipeline_full.py
+++ b/tests/test_pipeline_full.py
@@ -47,3 +47,49 @@ def test_pipeline_full(tmp_path, monkeypatch):
     assert (paths["wiki"] / "_sidebar.md").exists()
     wiki_files = list(paths["wiki"].glob("*.md"))
     assert wiki_files
+
+
+def test_pipeline_full_with_image(tmp_path, monkeypatch):
+    paths = {
+        "originals": tmp_path / "orig",
+        "work": tmp_path / "work",
+        "wiki": tmp_path / "wiki",
+        "tmp": tmp_path / "tmp",
+    }
+    for p in paths.values():
+        p.mkdir(parents=True, exist_ok=True)
+
+    doc_path = paths["originals"] / "img.docx"
+    doc = Document()
+    run = doc.add_paragraph().add_run("Title")
+    run.bold = True
+    run.font.size = Pt(16)
+    doc.save(doc_path)
+
+    def fake_run(cmd, capture_output=True, text=True):
+        md = Path(cmd[-1])
+        md.write_text("# Title\n![alt](media/img.png)", encoding="utf-8")
+        media_dir = None
+        for part in cmd:
+            if part.startswith("--extract-media="):
+                media_dir = Path(part.split("=", 1)[1])
+        if media_dir is not None:
+            media_dir.mkdir(parents=True, exist_ok=True)
+            (media_dir / "img.png").write_text("binary", encoding="utf-8")
+        class R:
+            returncode = 0
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
+    monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", lambda: None)
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+
+    result = runner.invoke(app, ["full"])
+    assert result.exit_code == 0
+
+    img_file = paths["wiki"] / "assets" / "media" / "img.png"
+    assert img_file.exists()
+    md_files = list(paths["wiki"].glob("*.md"))
+    assert any("assets/media/img.png" in f.read_text(encoding="utf-8") for f in md_files)


### PR DESCRIPTION
## Summary
- extract media when converting DOCX to Markdown
- update CLI to handle media folder and copy to wiki
- ensure converted Markdown links use `assets/media`
- test pipeline handles images correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad91a6ea4833388ec85da2bc1098e