### PR TITLE
feat: add reclassify utility

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -10,6 +10,7 @@ from .processing.docx_to_md import convert_docx_to_md
 from .processing.headings_map import build_headings_map, save_map_yaml
 from .processing.ingest import ingest_content
 from .processing.sidebar import build_sidebar
+from .processing.reclassify import reclassify_unclassified
 from rich.progress import track
 import yaml
 
@@ -260,4 +261,18 @@ def sidebar(
     output_path = cfg["paths"]["wiki"] / "_sidebar.md"
     build_sidebar(index_path, output_path, depth=depth)
     typer.echo("Sidebar generated")
+
+
+@app.command()
+def reclassify(
+    threshold: float = typer.Option(0.3, "--threshold", "-t", help="Match threshold")
+) -> None:
+    """Reclassify sections from 99_unclassified.md."""
+    wiki_dir = cfg["paths"]["wiki"]
+    unclassified = wiki_dir / "99_unclassified.md"
+    if not unclassified.exists():
+        raise typer.Exit(code=1)
+    index_path = cfg["paths"]["work"] / "index.yaml"
+    reclassify_unclassified(unclassified, index_path, wiki_dir, threshold=threshold)
+    typer.echo("Reclassification completed")
 

--- a/src/wiki_documental/processing/reclassify.py
+++ b/src/wiki_documental/processing/reclassify.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+from pathlib import Path
+import csv
+from typing import Any, Dict, List
+
+import yaml
+
+from .ingest import _flatten_index, _parse_sections
+
+
+def reclassify_unclassified(
+    unclassified_path: Path,
+    index_path: Path,
+    wiki_dir: Path,
+    threshold: float = 0.3,
+    report_path: Path | None = None,
+) -> None:
+    """Reclassify sections from ``unclassified_path`` using ``index_path``.
+
+    Blocks matching a title in the index above ``threshold`` are appended to the
+    corresponding markdown file. Unmatched blocks are written to ``report_path``
+    as CSV with columns ``title`` and ``content``.
+    """
+
+    with index_path.open("r", encoding="utf-8") as f:
+        index_data = yaml.safe_load(f) or []
+    entries = _flatten_index(index_data)
+
+    sections = _parse_sections(unclassified_path)
+
+    if report_path is None:
+        report_path = unclassified_path.parent / "report_reclassify.csv"
+
+    unmatched: List[dict[str, str]] = []
+
+    for title, lines in sections:
+        if title == "__intro__":
+            continue
+        best_ratio = 0.0
+        best_entry: Dict[str, Any] | None = None
+        for entry in entries:
+            ratio = SequenceMatcher(
+                None, title.lower(), str(entry.get("title", "")).lower()
+            ).ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best_entry = entry
+        if best_entry and best_ratio >= threshold and best_entry.get("slug"):
+            identifier = str(best_entry.get("id", "")).replace(".", "-")
+            md_file = wiki_dir / f"{identifier}_{best_entry['slug']}.md"
+            md_file.parent.mkdir(parents=True, exist_ok=True)
+            with md_file.open("a", encoding="utf-8") as f:
+                if lines and not lines[-1].endswith("\n"):
+                    lines[-1] += "\n"
+                f.writelines(lines)
+        else:
+            unmatched.append({"title": title, "content": "".join(lines)})
+
+    if unmatched:
+        with report_path.open("w", encoding="utf-8", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=["title", "content"])
+            writer.writeheader()
+            writer.writerows(unmatched)

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -1,0 +1,48 @@
+import yaml
+from pathlib import Path
+from typer.testing import CliRunner
+
+from wiki_documental.cli import app
+from wiki_documental.processing.reclassify import reclassify_unclassified
+
+
+runner = CliRunner()
+
+
+def _setup(tmp_path):
+    work = tmp_path / "work"
+    wiki = tmp_path / "wiki"
+    work.mkdir()
+    wiki.mkdir()
+    index = [
+        {"id": "1", "title": "First", "slug": "first", "children": []},
+        {"id": "2", "title": "Second", "slug": "second", "children": []},
+    ]
+    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    first = wiki / "1_first.md"
+    first.write_text("---\n---\n# First\nold\n", encoding="utf-8")
+    second = wiki / "2_second.md"
+    second.write_text("---\n---\n# Second\n", encoding="utf-8")
+    unclassified = wiki / "99_unclassified.md"
+    unclassified.write_text("---\n---\n# First\nadd1\n# Unknown\nadd2\n", encoding="utf-8")
+    return work, wiki, unclassified
+
+
+def test_reclassify_unclassified(tmp_path):
+    work, wiki, unclassified = _setup(tmp_path)
+    reclassify_unclassified(unclassified, work / "index.yaml", wiki, threshold=0.3)
+    content = (wiki / "1_first.md").read_text(encoding="utf-8")
+    assert "add1" in content
+    report = wiki / "report_reclassify.csv"
+    assert report.exists()
+    rows = report.read_text(encoding="utf-8")
+    assert "Unknown" in rows
+
+
+def test_reclassify_cli(tmp_path, monkeypatch):
+    work, wiki, unclassified = _setup(tmp_path)
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work, "wiki": wiki}})
+    result = runner.invoke(app, ["reclassify", "--threshold", "0.3"])
+    assert result.exit_code == 0
+    assert "add1" in (wiki / "1_first.md").read_text(encoding="utf-8")
+


### PR DESCRIPTION
## Summary
- add `reclassify_unclassified` module to move blocks from `99_unclassified.md` into correct wiki files
- expose new `wiki reclassify` CLI command
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae08e6eb08333aa1693414993905a