### PR TITLE
fix: add doc_source to wiki front matter

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -122,7 +122,8 @@ def full() -> None:
 
     console.print("[bold]Ingesting content...[/bold]")
     cutoff = float(cfg.get("options", {}).get("cutoff_similarity", 0.5))
-    ingest_content(tmp_full, index_path, wiki_dir, cutoff=cutoff)
+    doc_source = docx_files[0].stem if docx_files else None
+    ingest_content(tmp_full, index_path, wiki_dir, cutoff=cutoff, doc_source=doc_source)
 
     console.print("[bold]Generating sidebar...[/bold]")
     build_sidebar(index_path, wiki_dir / "_sidebar.md")
@@ -245,7 +246,8 @@ def ingest(file: Path) -> None:
     index_path = cfg["paths"]["work"] / "index.yaml"
     wiki_dir = cfg["paths"]["wiki"]
     cutoff = float(cfg.get("options", {}).get("cutoff_similarity", 0.5))
-    ingest_content(file, index_path, wiki_dir, cutoff=cutoff)
+    doc_source = file.stem
+    ingest_content(file, index_path, wiki_dir, cutoff=cutoff, doc_source=doc_source)
     typer.echo("Content ingested")
 
 

--- a/src/wiki_documental/processing/ingest.py
+++ b/src/wiki_documental/processing/ingest.py
@@ -62,7 +62,13 @@ def _parse_sections(md_path: Path) -> List[tuple[str, List[str]]]:
     return sections
 
 
-def ingest_content(md_path: Path, index_path: Path, out_dir: Path, cutoff: float = 0.5) -> None:
+def ingest_content(
+    md_path: Path,
+    index_path: Path,
+    out_dir: Path,
+    cutoff: float = 0.5,
+    doc_source: str | Path | None = None,
+) -> None:
     """Fragment markdown file according to index.yaml and store pieces."""
     with index_path.open("r", encoding="utf-8") as f:
         index_data = yaml.safe_load(f) or []
@@ -91,7 +97,12 @@ def ingest_content(md_path: Path, index_path: Path, out_dir: Path, cutoff: float
 
     out_dir.mkdir(parents=True, exist_ok=True)
     created = datetime.utcnow().isoformat()
-    header = f"---\nsource: {md_path.name}\ncreated: {created}\n---\n"
+    header_lines = ["---", f"source: {md_path.name}"]
+    if doc_source is not None:
+        header_lines.append(f"doc_source: {Path(doc_source).stem}.docx")
+    header_lines.append(f"created: {created}")
+    header_lines.append("---\n")
+    header = "\n".join(header_lines)
 
     for entry in entries:
         slug = entry["slug"]

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -16,7 +16,7 @@ def test_ingest_content(tmp_path):
     index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
 
     out_dir = tmp_path / "wiki"
-    ingest_content(md, index_path, out_dir, cutoff=0.5)
+    ingest_content(md, index_path, out_dir, cutoff=0.5, doc_source="estado_actual")
 
     first = out_dir / "1_x.md"
     second = out_dir / "2_z.md"
@@ -29,6 +29,7 @@ def test_ingest_content(tmp_path):
     end = lines.index("---", 1)
     meta = yaml.safe_load("\n".join(lines[1:end]))
     assert meta["source"] == md.name
+    assert meta["doc_source"] == "estado_actual.docx"
     assert lines[end + 1].startswith("#")
     assert "## Y" in content
     assert "### Zeta" in content


### PR DESCRIPTION
## Summary
- expose doc_source argument in ingest utilities
- preserve doc_source in front matter via CLI full and ingest commands
- validate doc_source in unit tests

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae0a716608333914fc116eb6d1340