### PR TITLE
TASK IMG-002 – Corrección de rutas de imágenes

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -74,7 +74,7 @@ def full() -> None:
             raise typer.Exit(code=1)
 
     console.print("[bold]Converting DOCX to Markdown...[/bold]")
-    media_dir = md_raw_dir / "media"
+    media_dir = md_raw_dir
     for docx in track(norm_dir.glob("*.docx"), description="Convert"):
         out = md_raw_dir / f"{docx.stem}.md"
         try:
@@ -132,6 +132,11 @@ def full() -> None:
     media_src = md_raw_dir / "media"
     if media_src.exists():
         dest = wiki_dir / "assets" / "media"
+        double_media = dest / "media"
+        if double_media.exists():
+            for img in double_media.iterdir():
+                shutil.move(img, dest)
+            shutil.rmtree(double_media)
         if dest.exists():
             shutil.rmtree(dest)
         shutil.copytree(media_src, dest)
@@ -161,7 +166,7 @@ def convert(file: Path) -> None:
     dest_dir = cfg["paths"]["work"] / "md_raw"
     dest_dir.mkdir(parents=True, exist_ok=True)
     out_file = dest_dir / f"{file.stem}.md"
-    convert_docx_to_md(file, out_file, dest_dir / "media")
+    convert_docx_to_md(file, out_file, dest_dir)
     typer.echo(f"Converted markdown saved to {out_file}")
 
 

--- a/src/wiki_documental/processing/ingest.py
+++ b/src/wiki_documental/processing/ingest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
-from .md_post import post_process_text
+from .md_post import post_process_text, fix_image_links, warn_missing_images
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
 
@@ -114,10 +114,14 @@ def ingest_content(
         prefix = str(entry.get("id", "")).replace(".", "-")
         path = out_dir / f"{prefix}_{slug}.md"
         final_text = post_process_text(header + text)
+        final_text = fix_image_links(final_text)
+        warn_missing_images(final_text, out_dir)
         with path.open("w", encoding="utf-8") as f:
             f.write(final_text)
 
     if unclassified:
         final_text = post_process_text(header + "".join(unclassified))
+        final_text = fix_image_links(final_text)
+        warn_missing_images(final_text, out_dir)
         with (out_dir / "99_unclassified.md").open("w", encoding="utf-8") as f:
             f.write(final_text)

--- a/src/wiki_documental/processing/md_post.py
+++ b/src/wiki_documental/processing/md_post.py
@@ -2,6 +2,30 @@ from __future__ import annotations
 
 import re
 from typing import List
+from pathlib import Path
+
+IMAGE_LINK_RE = re.compile(r"!\[([^\]]*)\]\((?:\./|\.\./)*media/([^)]+)\)")
+
+
+def fix_image_links(text: str) -> str:
+    """Replace media paths with assets/media paths."""
+
+    def repl(match: re.Match[str]) -> str:
+        alt = match.group(1)
+        filename = match.group(2)
+        return f"![{alt}](assets/media/{filename})"
+
+    return IMAGE_LINK_RE.sub(repl, text)
+
+
+ASSET_LINK_RE = re.compile(r"!\[[^\]]*\]\((assets/media/[^)]+)\)")
+
+
+def warn_missing_images(text: str, wiki_dir: Path) -> None:
+    """Print warning for any linked images that do not exist."""
+    for rel in ASSET_LINK_RE.findall(text):
+        if not (wiki_dir / rel).exists():
+            print(f"Warning: missing image {wiki_dir / rel}")
 
 
 _HEADING2_RE = re.compile(r"^##\s")

--- a/tests/test_md_post.py
+++ b/tests/test_md_post.py
@@ -1,4 +1,9 @@
-from wiki_documental.processing.md_post import post_process_text, clean_markdown
+from wiki_documental.processing.md_post import (
+    post_process_text,
+    clean_markdown,
+    fix_image_links,
+    warn_missing_images,
+)
 
 
 def test_clean_and_spacing():
@@ -23,3 +28,17 @@ def test_heading_cleanup():
     assert lines[0] == '## Title'
     assert lines[1] == ''
     assert lines[2] == '### Another Title'
+
+
+def test_fix_image_links_and_warning(tmp_path, capsys):
+    text = '![a](media/img.png) and ![](../media/img2.jpg)'
+    assets = tmp_path / 'assets' / 'media'
+    assets.mkdir(parents=True)
+    (assets / 'img.png').write_text('x', encoding='utf-8')
+
+    fixed = fix_image_links(text)
+    warn_missing_images(fixed, tmp_path)
+    captured = capsys.readouterr()
+    assert 'assets/media/img.png' in fixed
+    assert 'assets/media/img2.jpg' in fixed
+    assert 'img2.jpg' in captured.out

--- a/tests/test_pipeline_full.py
+++ b/tests/test_pipeline_full.py
@@ -74,8 +74,8 @@ def test_pipeline_full_with_image(tmp_path, monkeypatch):
             if part.startswith("--extract-media="):
                 media_dir = Path(part.split("=", 1)[1])
         if media_dir is not None:
-            media_dir.mkdir(parents=True, exist_ok=True)
-            (media_dir / "img.png").write_text("binary", encoding="utf-8")
+            (media_dir / "media").mkdir(parents=True, exist_ok=True)
+            (media_dir / "media" / "img.png").write_text("binary", encoding="utf-8")
         class R:
             returncode = 0
             stderr = ""


### PR DESCRIPTION
## Summary
- avoid nested media folders when converting docs
- check and cleanup double media directory when copying assets
- rewrite relative media paths on ingest
- warn for missing images
- update tests for new image handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af62196788333bba9d89b7da33057