### PR TITLE
TASK META-005 – Soporte para múltiples orígenes en doc_source

### DIFF
--- a/src/wiki_documental/processing/ingest.py
+++ b/src/wiki_documental/processing/ingest.py
@@ -62,6 +62,29 @@ def _parse_sections(md_path: Path) -> List[tuple[str, List[str]]]:
     return sections
 
 
+def _read_front_matter(path: Path) -> Dict[str, Any]:
+    """Return YAML front matter dict from an existing file."""
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        lines = f.readlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}
+    content = "".join(lines[1:end])
+    try:
+        data = yaml.safe_load(content) or {}
+    except Exception:
+        data = {}
+    return data
+
+
 def ingest_content(
     md_path: Path,
     index_path: Path,
@@ -96,13 +119,6 @@ def ingest_content(
             unclassified.extend(lines)
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    created = datetime.utcnow().isoformat()
-    header_lines = ["---", f"source: {md_path.name}"]
-    if doc_source is not None:
-        header_lines.append(f"doc_source: {Path(doc_source).stem}.docx")
-    header_lines.append(f"created: {created}")
-    header_lines.append("---\n")
-    header = "\n".join(header_lines)
 
     for entry in entries:
         slug = entry["slug"]
@@ -113,6 +129,36 @@ def ingest_content(
             continue
         prefix = str(entry.get("id", "")).replace(".", "-")
         path = out_dir / f"{prefix}_{slug}.md"
+
+        meta = _read_front_matter(path)
+        created = meta.get("created", datetime.utcnow().isoformat())
+
+        existing_sources = meta.get("doc_source")
+        sources: List[str] = []
+        if isinstance(existing_sources, list):
+            sources.extend(existing_sources)
+        elif isinstance(existing_sources, str):
+            sources.append(existing_sources)
+
+        if doc_source is not None:
+            new_src = f"{Path(doc_source).stem}.docx"
+            if new_src not in sources:
+                sources.append(new_src)
+
+        header_lines = ["---", f"source: {md_path.name}"]
+        if sources:
+            if len(sources) == 1:
+                header_lines.append(f"doc_source: {sources[0]}")
+            else:
+                header_lines.append("doc_source:")
+                for s in sorted(sources):
+                    header_lines.append(f"  - {s}")
+        elif doc_source is not None:
+            header_lines.append(f"doc_source: {Path(doc_source).stem}.docx")
+        header_lines.append(f"created: {created}")
+        header_lines.append("---\n")
+        header = "\n".join(header_lines)
+
         final_text = post_process_text(header + text)
         final_text = fix_image_links(final_text)
         warn_missing_images(final_text, out_dir)
@@ -120,6 +166,32 @@ def ingest_content(
             f.write(final_text)
 
     if unclassified:
+        meta = _read_front_matter(out_dir / "99_unclassified.md")
+        created = meta.get("created", datetime.utcnow().isoformat())
+        existing_sources = meta.get("doc_source")
+        sources: List[str] = []
+        if isinstance(existing_sources, list):
+            sources.extend(existing_sources)
+        elif isinstance(existing_sources, str):
+            sources.append(existing_sources)
+        if doc_source is not None:
+            new_src = f"{Path(doc_source).stem}.docx"
+            if new_src not in sources:
+                sources.append(new_src)
+        header_lines = ["---", f"source: {md_path.name}"]
+        if sources:
+            if len(sources) == 1:
+                header_lines.append(f"doc_source: {sources[0]}")
+            else:
+                header_lines.append("doc_source:")
+                for s in sorted(sources):
+                    header_lines.append(f"  - {s}")
+        elif doc_source is not None:
+            header_lines.append(f"doc_source: {Path(doc_source).stem}.docx")
+        header_lines.append(f"created: {created}")
+        header_lines.append("---\n")
+        header = "\n".join(header_lines)
+
         final_text = post_process_text(header + "".join(unclassified))
         final_text = fix_image_links(final_text)
         warn_missing_images(final_text, out_dir)

--- a/tests/test_ingest_sources.py
+++ b/tests/test_ingest_sources.py
@@ -1,0 +1,28 @@
+import yaml
+from wiki_documental.processing.ingest import ingest_content
+
+
+def test_ingest_multiple_sources(tmp_path):
+    md_a = tmp_path / "a.md"
+    md_a.write_text("# Introducción\nA\n", encoding="utf-8")
+
+    md_b = tmp_path / "b.md"
+    md_b.write_text("# Introducción\nB\n", encoding="utf-8")
+
+    index = [{"id": "1", "title": "Introducción", "slug": "introduccion", "children": []}]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+
+    out_dir = tmp_path / "wiki"
+
+    ingest_content(md_a, index_path, out_dir, cutoff=0.5, doc_source="DocA")
+    ingest_content(md_b, index_path, out_dir, cutoff=0.5, doc_source="DocB")
+
+    final = out_dir / "1_introduccion.md"
+    assert final.exists()
+    content = final.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    assert lines[0] == "---"
+    end = lines.index("---", 1)
+    meta = yaml.safe_load("\n".join(lines[1:end]))
+    assert sorted(meta["doc_source"]) == ["DocA.docx", "DocB.docx"]


### PR DESCRIPTION
## Summary
- allow ingest to read/update front matter when regenerating
- append new values to `doc_source` without duplication
- include new tests covering multiple doc_source support

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afa5296ec83338254aa8ba24e1c6f