### PR TITLE
TASK SYS-003 – Implementación real de wiki reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Example hierarchical entry:
 
 ### `wiki full`
 
-Run the entire conversion pipeline (placeholder). It currently just checks that Pandoc is installed and prints a message.
+Run the entire conversion pipeline from DOCX originals to a Docsify wiki.
 
 ### `wiki reset`
 
-Reset the working directory (placeholder for future clean-up logic).
+Remove generated Markdown, YAML and CSV files from the `work` and `wiki` directories while preserving `index.html` and other static assets.
 
 ### `wiki normalize`
 

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -1,6 +1,7 @@
 import shutil
 import typer
 from pathlib import Path
+from shutil import rmtree
 from rich.console import Console
 
 from . import ensure_pandoc, __version__
@@ -15,6 +16,23 @@ from rich.progress import track
 import yaml
 
 app = typer.Typer(add_completion=False, add_help_option=True)
+
+
+def reset_environment(cfg: dict) -> None:
+    """Remove generated artifacts from wiki and work directories."""
+    console = Console()
+    paths = [cfg["paths"]["wiki"], cfg["paths"]["work"]]
+    for path in paths:
+        for pattern in ["*.md", "*.yaml", "*.csv"]:
+            for f in Path(path).rglob(pattern):
+                if f.name == "index.html":
+                    continue
+                f.unlink()
+                console.log(f"Deleted {f}")
+    media_dir = Path(cfg["paths"]["wiki"]) / "assets" / "media"
+    if media_dir.exists():
+        rmtree(media_dir)
+        console.log(f"Removed directory {media_dir}")
 
 
 def _version_callback(value: bool) -> None:
@@ -146,8 +164,8 @@ def full() -> None:
 
 @app.command()
 def reset() -> None:
-    """Reset wiki state (placeholder)."""
-    typer.echo("Running reset placeholder")
+    """Reset wiki and work directories removing generated files."""
+    reset_environment(cfg)
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- implement `reset_environment` and hook `wiki reset` to it
- preserve index.html while cleaning
- document updated `wiki full` and `wiki reset`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9fec279c8333b0a4eb1549cd41b0