### PR TITLE
TASK SYS‑004 – Limpieza completa del directorio work y corrección de rutas media

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run the entire conversion pipeline from DOCX originals to a Docsify wiki.
 
 ### `wiki reset`
 
-Remove generated Markdown, YAML and CSV files from the `work` and `wiki` directories while preserving `index.html` and other static assets.
+Remove all generated Markdown, YAML and CSV files from the `work` and `wiki` directories. The command also deletes `work/md_raw`, `work/normalized`, `work/tmp` and any `media` folders to ensure a completely clean state while preserving `index.html` and other static assets.
 
 ### `wiki normalize`
 

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -28,7 +28,7 @@ Se actualiza tras cada cambio relevante mediante tareas formales.
 |--------|---------|----------------|------------|
 | `cli.py` | Entrada principal del sistema | ✅ (`wiki ...`) | ✅ |
 | `config.py` | Carga de rutas y opciones (`cfg`) | ✅ (interno) | ✅ |
-| `reset` | Limpia entorno de trabajo | ✅ (próxima TASK SYS‑03) | 💜 |
+| `reset` | Limpia entorno de trabajo | ✅ | ✅ |
 | `reclassify.py` | CLI: `wiki reclassify` | ✅ | ✅ |
 | `check_sidebar_links.py` | Verifica enlaces en CI | ❌ (solo script) | ✅ |
 

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -34,6 +34,18 @@ def reset_environment(cfg: dict) -> None:
         rmtree(media_dir)
         console.log(f"Removed directory {media_dir}")
 
+    work_dir = Path(cfg["paths"]["work"])
+    paths_to_clean = [
+        work_dir / "md_raw",
+        work_dir / "normalized",
+        work_dir / "tmp",
+        work_dir / "media",
+    ]
+    for path in paths_to_clean:
+        if path.exists():
+            rmtree(path)
+            console.log(f"Removed directory {path}")
+
 
 def _version_callback(value: bool) -> None:
     if value:
@@ -92,11 +104,10 @@ def full() -> None:
             raise typer.Exit(code=1)
 
     console.print("[bold]Converting DOCX to Markdown...[/bold]")
-    media_dir = md_raw_dir
     for docx in track(norm_dir.glob("*.docx"), description="Convert"):
         out = md_raw_dir / f"{docx.stem}.md"
         try:
-            convert_docx_to_md(docx, out, media_dir)
+            convert_docx_to_md(docx, out, wiki_dir)
         except Exception as exc:  # pragma: no cover - defensive
             console.print(f"Error converting {docx.name}: {exc}", style="red")
             raise typer.Exit(code=1)
@@ -184,7 +195,7 @@ def convert(file: Path) -> None:
     dest_dir = cfg["paths"]["work"] / "md_raw"
     dest_dir.mkdir(parents=True, exist_ok=True)
     out_file = dest_dir / f"{file.stem}.md"
-    convert_docx_to_md(file, out_file, dest_dir)
+    convert_docx_to_md(file, out_file, cfg["paths"]["wiki"])
     typer.echo(f"Converted markdown saved to {out_file}")
 
 

--- a/src/wiki_documental/processing/docx_to_md.py
+++ b/src/wiki_documental/processing/docx_to_md.py
@@ -3,12 +3,14 @@ import subprocess
 from wiki_documental.utils.system import ensure_pandoc
 
 
-def convert_docx_to_md(docx_path: Path, md_path: Path, media_path: Path | None = None) -> None:
+def convert_docx_to_md(
+    docx_path: Path, md_path: Path, wiki_dir: Path | None = None
+) -> None:
     """Convert DOCX to Markdown optionally extracting media files."""
     ensure_pandoc()
     cmd = ["pandoc", str(docx_path), "-f", "docx", "-t", "gfm"]
-    if media_path is not None:
-        cmd.append(f"--extract-media={media_path}")
+    if wiki_dir is not None:
+        cmd.append(f"--extract-media={wiki_dir / 'assets'}")
     cmd.extend(["-o", str(md_path)])
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:

--- a/tests/test_reset_work_dir.py
+++ b/tests/test_reset_work_dir.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from docx import Document
+from docx.shared import Pt
+from typer.testing import CliRunner
+
+from wiki_documental.cli import app
+
+runner = CliRunner()
+
+def _create_doc(path: Path) -> None:
+    doc = Document()
+    run = doc.add_paragraph().add_run("Title")
+    run.bold = True
+    run.font.size = Pt(16)
+    doc.add_paragraph("Body")
+    doc.save(path)
+
+def _fake_run(cmd, capture_output=True, text=True):
+    md = Path(cmd[-1])
+    md.write_text("# Title\nBody", encoding="utf-8")
+    for part in cmd:
+        if part.startswith("--extract-media="):
+            dest = Path(part.split("=", 1)[1]) / "media"
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "img.png").write_text("bin", encoding="utf-8")
+    class R:
+        returncode = 0
+        stderr = ""
+    return R()
+
+def test_reset_work_dir(tmp_path, monkeypatch):
+    paths = {
+        "originals": tmp_path / "orig",
+        "work": tmp_path / "work",
+        "wiki": tmp_path / "wiki",
+        "tmp": tmp_path / "tmp",
+    }
+    for p in paths.values():
+        p.mkdir(parents=True, exist_ok=True)
+
+    doc_file = paths["originals"] / "sample.docx"
+    _create_doc(doc_file)
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
+    monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", lambda: None)
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+
+    result = runner.invoke(app, ["full"])
+    assert result.exit_code == 0
+
+    assert (paths["work"] / "md_raw").exists()
+    assert (paths["wiki"] / "assets" / "media").exists()
+
+    result = runner.invoke(app, ["reset"])
+    assert result.exit_code == 0
+
+    for d in ["md_raw", "normalized", "tmp", "media"]:
+        assert not (paths["work"] / d).exists()
+    assert not (paths["wiki"] / "assets" / "media").exists()
+
+    for pattern in ["*.md", "*.yaml", "*.csv"]:
+        assert not list(paths["work"].rglob(pattern))
+        assert not list(paths["wiki"].rglob(pattern))
+


### PR DESCRIPTION
## Summary
- clean `work` directory more thoroughly when running `wiki reset`
- send pandoc media directly to `wiki/assets` directory
- update README and docs to reflect cleanup behavior
- cover new behavior with `test_reset_work_dir`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba3cfb7d08333a03e9c7c04e17e0d