### PR TITLE
feat(package): add static ZIP exporter for wiki

### DIFF
--- a/scripts/package_static.py
+++ b/scripts/package_static.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from zipfile import ZipFile
+from datetime import datetime
+import sys
+
+
+def main() -> None:
+    wiki_dir = Path("wiki")
+    required = ["index.html", "_sidebar.md", "assets/media"]
+    missing = [r for r in required if not (wiki_dir / r).exists()]
+    if missing:
+        print(f"\u274c No se puede empaquetar. Faltan: {missing}")
+        sys.exit(1)
+
+    output = Path("dist")
+    output.mkdir(exist_ok=True)
+    filename = output / f"wiki_documental_{datetime.now():%Y%m%d_%H%M}.zip"
+
+    with ZipFile(filename, "w") as zipf:
+        for file in wiki_dir.rglob("*"):
+            if file.is_file():
+                zipf.write(file, file.relative_to(wiki_dir.parent))
+    print(f"\u2705 Wiki empaquetada en: {filename}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -312,3 +312,11 @@ def reclassify(
     reclassify_unclassified(unclassified, index_path, wiki_dir, threshold=threshold)
     typer.echo("Reclassification completed")
 
+
+@app.command("package")
+def package_static() -> None:
+    """Empaqueta la wiki generada en un archivo ZIP entregable."""
+    from scripts.package_static import main as pack
+
+    pack()
+

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+from docx import Document
+from docx.shared import Pt
+from typer.testing import CliRunner
+from zipfile import ZipFile
+
+from wiki_documental.cli import app
+
+runner = CliRunner()
+
+
+def _create_doc(path: Path) -> None:
+    doc = Document()
+    run = doc.add_paragraph().add_run("Title")
+    run.bold = True
+    run.font.size = Pt(16)
+    doc.add_paragraph("Body")
+    doc.save(path)
+
+
+def _fake_run(cmd, capture_output=True, text=True):
+    md = Path(cmd[-1])
+    md.write_text("# Title\n![alt](media/img.png)", encoding="utf-8")
+    media_dir = None
+    for part in cmd:
+        if part.startswith("--extract-media="):
+            media_dir = Path(part.split("=", 1)[1])
+    if media_dir is not None:
+        (media_dir / "media").mkdir(parents=True, exist_ok=True)
+        (media_dir / "media" / "img.png").write_text("binary", encoding="utf-8")
+    class R:
+        returncode = 0
+        stderr = ""
+    return R()
+
+
+def test_package_static(tmp_path, monkeypatch):
+    paths = {
+        "originals": tmp_path / "orig",
+        "work": tmp_path / "work",
+        "wiki": tmp_path / "wiki",
+        "tmp": tmp_path / "tmp",
+    }
+    for p in paths.values():
+        p.mkdir(parents=True, exist_ok=True)
+
+    doc_path = paths["originals"] / "sample.docx"
+    _create_doc(doc_path)
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
+    monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", lambda: None)
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+
+    monkeypatch.chdir(tmp_path)
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+    result = runner.invoke(app, ["full"])
+    assert result.exit_code == 0
+
+    # Docsify landing page
+    (paths["wiki"] / "index.html").write_text("index", encoding="utf-8")
+
+    result = runner.invoke(app, ["package"])
+    assert result.exit_code == 0
+
+    dist = Path("dist")
+    zips = list(dist.glob("wiki_documental_*.zip"))
+    assert zips
+    zip_file = zips[0]
+
+    with ZipFile(zip_file) as z:
+        names = z.namelist()
+    assert "wiki/index.html" in names
+    assert "wiki/_sidebar.md" in names
+    assert any(n.startswith("wiki/assets/media/") for n in names)


### PR DESCRIPTION
## Summary
- add packaging script to produce static wiki zip
- expose `package` subcommand in CLI
- test packaging flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684babdc84008333b17dd21b8a78ab59