### PR TITLE
TASK SYS‑005 – Crear README.md base si no hay contenido navegable

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -170,6 +170,14 @@ def full() -> None:
             shutil.rmtree(dest)
         shutil.copytree(media_src, dest)
 
+    content_files = [f for f in wiki_dir.glob("*.md") if f.name not in ("_sidebar.md", "README.md")]
+    readme = wiki_dir / "README.md"
+    if not readme.exists() or not content_files:
+        readme.write_text(
+            "# Conocimiento Técnico Navantia\n\nEsta wiki fue generada automáticamente. Consulta el menú lateral para navegar.",
+            encoding="utf-8",
+        )
+
     console.print(f"\N{check mark} Wiki generada correctamente en: {wiki_dir / 'index.html'}")
 
 

--- a/src/wiki_documental/processing/sidebar.py
+++ b/src/wiki_documental/processing/sidebar.py
@@ -23,7 +23,10 @@ def build_sidebar(index_path: Path, output_path: Path, depth: int = 1) -> None:
     with index_path.open("r", encoding="utf-8") as f:
         index_data: List[Dict[str, object]] = yaml.safe_load(f) or []
 
-    lines: List[str] = ["* [Inicio](README.md)\n"]
+    lines: List[str] = []
+    readme = output_path.parent / "README.md"
+    if readme.exists():
+        lines.append("* [Inicio](README.md)\n")
 
     def add_entries(entries: List[Dict[str, object]], level: int) -> None:
         indent = "  " * level

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,7 @@ def test_sidebar_command(tmp_path, monkeypatch):
     (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
+    (work / "README.md").write_text("intro", encoding="utf-8")
 
     result = runner.invoke(app, ["sidebar"])
     assert result.exit_code == 0
@@ -147,6 +148,7 @@ def test_sidebar_command_depth(tmp_path, monkeypatch):
     (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
+    (work / "README.md").write_text("intro", encoding="utf-8")
 
     result = runner.invoke(app, ["sidebar", "--depth", "2"])
     assert result.exit_code == 0

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -32,6 +32,7 @@ def test_build_sidebar_default_depth(tmp_path):
     index_path = tmp_path / "index.yaml"
     index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
     out_file = tmp_path / "_sidebar.md"
+    (tmp_path / "README.md").write_text("intro", encoding="utf-8")
     build_sidebar(index_path, out_file)
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
@@ -46,6 +47,7 @@ def test_build_sidebar_depth_3(tmp_path):
     index_path = tmp_path / "index.yaml"
     index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
     out_file = tmp_path / "_sidebar.md"
+    (tmp_path / "README.md").write_text("intro", encoding="utf-8")
     build_sidebar(index_path, out_file, depth=3)
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
@@ -53,3 +55,14 @@ def test_build_sidebar_depth_3(tmp_path):
     assert lines[1] == "* [Contexto](1_contexto.md)"
     assert lines[2] == "  * [Funcion](1-1_funcion.md)"
     assert lines[3] == "    * [Detalles](1-1-1_detalles.md)"
+
+
+def test_build_sidebar_without_readme(tmp_path):
+    index = _sample_index()
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    out_file = tmp_path / "_sidebar.md"
+    build_sidebar(index_path, out_file)
+
+    lines = out_file.read_text(encoding="utf-8").splitlines()
+    assert lines == ["* [Contexto](1_contexto.md)"]


### PR DESCRIPTION
## Summary
- auto-create README.md on `wiki full` when the wiki has no content
- only add a README link in sidebar when README exists
- adjust CLI and sidebar tests to account for README logic
- add regression test for sidebar generation without README

## Testing
- `poetry run pytest -q`
- `poetry run python scripts/check_sidebar_links.py`

------
https://chatgpt.com/codex/tasks/task_e_684baf1dd1508333a386ed25a8f0ed05