### PR TITLE
TASK META‑006 – Asignar doc_source por bloque según .docx original

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -152,8 +152,9 @@ def full() -> None:
 
     console.print("[bold]Ingesting content...[/bold]")
     cutoff = float(cfg.get("options", {}).get("cutoff_similarity", 0.5))
-    doc_source = docx_files[0].stem if docx_files else None
-    ingest_content(tmp_full, index_path, wiki_dir, cutoff=cutoff, doc_source=doc_source)
+
+    for md in track(sorted(md_raw_dir.glob("*.md")), description="Ingest"):
+        ingest_content(md, index_path, wiki_dir, cutoff=cutoff, doc_source=md.stem)
 
     console.print("[bold]Generating sidebar...[/bold]")
     build_sidebar(index_path, wiki_dir / "_sidebar.md")

--- a/tests/test_pipeline_doc_sources.py
+++ b/tests/test_pipeline_doc_sources.py
@@ -1,0 +1,67 @@
+import yaml
+from docx import Document
+from docx.shared import Pt
+from pathlib import Path
+from typer.testing import CliRunner
+
+from wiki_documental.cli import app
+
+runner = CliRunner()
+
+
+def test_full_multiple_doc_sources(tmp_path, monkeypatch):
+    paths = {
+        "originals": tmp_path / "orig",
+        "work": tmp_path / "work",
+        "wiki": tmp_path / "wiki",
+        "tmp": tmp_path / "tmp",
+    }
+    for p in paths.values():
+        p.mkdir(parents=True, exist_ok=True)
+
+    doc_a = paths["originals"] / "DocA.docx"
+    doc_b = paths["originals"] / "DocB.docx"
+
+    for doc_path, text in [(doc_a, "A"), (doc_b, "B")]:
+        doc = Document()
+        run = doc.add_paragraph().add_run("Introducción")
+        run.bold = True
+        run.font.size = Pt(16)
+        doc.add_paragraph(text)
+        doc.save(doc_path)
+
+    def fake_run(cmd, capture_output=True, text=True):
+        out = Path(cmd[-1])
+        out.write_text("# Introducción\nX", encoding="utf-8")
+        class R:
+            returncode = 0
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
+    monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", lambda: None)
+
+    def fake_build_headings_map(_):
+        return [{"level": 1, "title": "Introducción", "slug": "introduccion"}]
+
+    monkeypatch.setattr(
+        "wiki_documental.processing.headings_map.build_headings_map",
+        fake_build_headings_map,
+    )
+
+    monkeypatch.setattr(
+        "wiki_documental.cli.cfg",
+        {"paths": paths, "options": {"cutoff_similarity": 0.5}},
+    )
+
+    result = runner.invoke(app, ["full"])
+    assert result.exit_code == 0
+
+    final = paths["wiki"] / "1_introduccion.md"
+    assert final.exists()
+    lines = final.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "---"
+    end = lines.index("---", 1)
+    meta = yaml.safe_load("\n".join(lines[1:end]))
+    assert sorted(meta["doc_source"]) == ["DocA.docx", "DocB.docx"]


### PR DESCRIPTION
## Summary
- ingest each converted Markdown file individually so every fragment stores its source DOCX name
- add regression test checking multiple DOCX sources are kept in front‑matter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb8a02cec833389904c7b2debfa19