### PR TITLE
TASK IMG-004 – Normalización de rutas de imágenes para navegación web

### DIFF
--- a/src/wiki_documental/processing/docx_to_md.py
+++ b/src/wiki_documental/processing/docx_to_md.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import subprocess
 from wiki_documental.utils.system import ensure_pandoc
-from .md_post import fix_image_links
+from .md_post import fix_image_links, normalize_image_paths
 
 
 def convert_docx_to_md(
@@ -18,5 +18,6 @@ def convert_docx_to_md(
         raise RuntimeError(f"Pandoc error: {result.stderr}")
     text = md_path.read_text(encoding="utf-8")
     text = fix_image_links(text)
+    text = normalize_image_paths(text)
     assert "assets/assets/media/" not in text, "❌ Doble ruta assets detectada"
     md_path.write_text(text, encoding="utf-8")

--- a/src/wiki_documental/processing/ingest.py
+++ b/src/wiki_documental/processing/ingest.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
-from .md_post import post_process_text, fix_image_links, warn_missing_images
+from .md_post import (
+    post_process_text,
+    fix_image_links,
+    warn_missing_images,
+    normalize_image_paths,
+)
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
 
@@ -161,6 +166,7 @@ def ingest_content(
 
         final_text = post_process_text(header + text)
         final_text = fix_image_links(final_text)
+        final_text = normalize_image_paths(final_text)
         assert "assets/assets/media/" not in final_text, "\u274c Doble ruta assets detectada"
         warn_missing_images(final_text, out_dir)
         with path.open("w", encoding="utf-8") as f:
@@ -195,6 +201,7 @@ def ingest_content(
 
         final_text = post_process_text(header + "".join(unclassified))
         final_text = fix_image_links(final_text)
+        final_text = normalize_image_paths(final_text)
         assert "assets/assets/media/" not in final_text, "\u274c Doble ruta assets detectada"
         warn_missing_images(final_text, out_dir)
         with (out_dir / "99_unclassified.md").open("w", encoding="utf-8") as f:

--- a/src/wiki_documental/processing/md_post.py
+++ b/src/wiki_documental/processing/md_post.py
@@ -13,6 +13,14 @@ def fix_image_links(text: str) -> str:
     return IMAGE_PREFIX_RE.sub(r"\1assets/media/", text)
 
 
+def normalize_image_paths(md_text: str) -> str:
+    """Normalize image paths replacing backslashes and absolute drive paths."""
+
+    md_text = md_text.replace("\\", "/")
+    md_text = re.sub(r"[a-zA-Z]:/[^)]*", "assets/media/", md_text)
+    return md_text
+
+
 ASSET_LINK_RE = re.compile(r"!\[[^\]]*\]\((assets/media/[^)]+)\)")
 
 

--- a/tests/test_md_post.py
+++ b/tests/test_md_post.py
@@ -3,6 +3,7 @@ from wiki_documental.processing.md_post import (
     clean_markdown,
     fix_image_links,
     warn_missing_images,
+    normalize_image_paths,
 )
 
 
@@ -47,3 +48,11 @@ def test_fix_image_links_and_warning(tmp_path, capsys):
 def test_fix_image_links_no_duplicate():
     text = '![alt](assets/media/img.png)'
     assert fix_image_links(text) == text
+
+
+def test_normalize_image_paths():
+    text = '![alt](assets\\media\\img.png) and ![](C:/temp/foo.png)'
+    result = normalize_image_paths(text)
+    assert '\\' not in result
+    assert 'C:/' not in result
+    assert 'assets/media/img.png' in result

--- a/tests/test_pipeline_full.py
+++ b/tests/test_pipeline_full.py
@@ -68,7 +68,7 @@ def test_pipeline_full_with_image(tmp_path, monkeypatch):
 
     def fake_run(cmd, capture_output=True, text=True):
         md = Path(cmd[-1])
-        md.write_text("# Title\n![alt](media/img.png)", encoding="utf-8")
+        md.write_text("# Title\n![alt](media\\img.png)", encoding="utf-8")
         media_dir = None
         for part in cmd:
             if part.startswith("--extract-media="):
@@ -92,5 +92,7 @@ def test_pipeline_full_with_image(tmp_path, monkeypatch):
     img_file = paths["wiki"] / "assets" / "media" / "img.png"
     assert img_file.exists()
     md_files = list(paths["wiki"].glob("*.md"))
-    assert any("assets/media/img.png" in f.read_text(encoding="utf-8") for f in md_files)
-    assert all("assets/assets/media" not in f.read_text(encoding="utf-8") for f in md_files)
+    contents = [f.read_text(encoding="utf-8") for f in md_files]
+    assert any("assets/media/img.png" in c for c in contents)
+    assert all("assets/assets/media" not in c for c in contents)
+    assert all("\\" not in c for c in contents)


### PR DESCRIPTION
## Summary
- normalize image paths to web-friendly format
- ensure docx conversion and ingestion steps call the new normalization logic
- cover new functionality with tests

## Testing
- `poetry run pytest -q`
- `poetry run python scripts/check_sidebar_links.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684bba930c0c8333ac9e38498f4e2fc1