### PR TITLE
QA-001 Ignore deep slugs in verify

### DIFF
--- a/src/wiki_documental/processing/verify_pre_ingest.py
+++ b/src/wiki_documental/processing/verify_pre_ingest.py
@@ -6,19 +6,29 @@ from typing import Dict, List, Any
 import yaml
 
 
+def _slug_level(slug: str) -> int:
+    """Return heading level from slug based on hyphen count."""
+    return slug.count("-") + 1
+
+
 def _load_map_slugs(path: Path) -> set[str]:
     if not path.exists():
         return set()
     with path.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or []
-    return {item.get("slug") for item in data if item.get("slug")}
+    slugs: set[str] = set()
+    for item in data:
+        slug = item.get("slug")
+        if slug and _slug_level(slug) <= 2:
+            slugs.add(slug)
+    return slugs
 
 
 def _extract_slugs(entries: List[Dict[str, Any]]) -> set[str]:
     slugs: set[str] = set()
     for entry in entries:
         slug = entry.get("slug")
-        if slug:
+        if slug and _slug_level(slug) <= 2:
             slugs.add(slug)
         children = entry.get("children", [])
         if children:

--- a/tests/test_verify_pre_ingest.py
+++ b/tests/test_verify_pre_ingest.py
@@ -26,6 +26,26 @@ def test_compare_map_index(tmp_path):
     assert diffs == {"missing_in_index": [], "missing_in_map": []}
 
 
+def test_compare_map_index_ignore_deep(tmp_path):
+    map_data = [
+        {"level": 1, "title": "H1", "slug": "h1"},
+        {"level": 2, "title": "H1.1", "slug": "h1-1"},
+        {"level": 3, "title": "H1.1.1", "slug": "h1-1-1"},
+    ]
+    index_data = [
+        {"title": "H1", "slug": "h1", "children": [
+            {"level": 2, "title": "H1.1", "slug": "h1-1"}
+        ]}
+    ]
+    map_file = tmp_path / "map.yaml"
+    index_file = tmp_path / "index.yaml"
+    map_file.write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+    index_file.write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
+
+    diffs = compare_map_index(map_file, index_file)
+    assert diffs == {"missing_in_index": [], "missing_in_map": []}
+
+
 
 def test_verify_cli(tmp_path, monkeypatch):
     map_data = [{"level": 1, "title": "A", "slug": "a"}]


### PR DESCRIPTION
## Summary
- skip map/index comparison when slug depth is greater than level 2
- test verifying that deeper slugs are ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c043a3f248333a2454e5f89b1195b