### PR TITLE
feat(nav): modular sidebar from front matter

### DIFF
--- a/sidebar/_auto_index.md
+++ b/sidebar/_auto_index.md
@@ -1,0 +1,1 @@
+<!-- Auto-generated file -->

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -11,6 +11,8 @@ from .processing.docx_to_md import convert_docx_to_md
 from .processing.headings_map import build_headings_map, save_map_yaml
 from .processing.ingest import ingest_content
 from .processing.sidebar import build_sidebar
+from tools.sidebar_from_frontmatter import generate_sidebar
+from tools.update_sidebar import update_sidebar
 from .processing.reclassify import reclassify_unclassified
 from rich.progress import track
 import yaml
@@ -157,7 +159,16 @@ def full() -> None:
         ingest_content(md, index_path, wiki_dir, cutoff=cutoff, doc_source=md.stem)
 
     console.print("[bold]Generating sidebar...[/bold]")
-    build_sidebar(index_path, wiki_dir / "_sidebar.md")
+    template = Path(__file__).resolve().parents[2] / "wiki" / "_sidebar.md"
+    sidebar_dest = wiki_dir / "_sidebar.md"
+    if not sidebar_dest.exists():
+        shutil.copy(template, sidebar_dest)
+    auto_text = generate_sidebar(wiki_dir)
+    sidebar_dir = wiki_dir.parent / "sidebar"
+    sidebar_dir.mkdir(parents=True, exist_ok=True)
+    auto_file = sidebar_dir / "_auto_index.md"
+    auto_file.write_text(auto_text, encoding="utf-8")
+    update_sidebar(sidebar_dest, auto_file)
 
     media_src = md_raw_dir / "media"
     if media_src.exists():

--- a/tests/test_sidebar_meta.py
+++ b/tests/test_sidebar_meta.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from tools.sidebar_from_frontmatter import generate_sidebar
+from tools.update_sidebar import update_sidebar
+
+
+def test_generate_sidebar_and_update(tmp_path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+
+    # pages with different sections and weights
+    (wiki / "a.md").write_text(
+        """---
+title: Tema A
+path: a.md
+section_path: Seccion/Uno
+weight: 2
+---
+body""",
+        encoding="utf-8",
+    )
+    (wiki / "b.md").write_text(
+        """---
+title: Tema B
+path: b.md
+section_path: Seccion/Uno
+weight: 1
+---
+body""",
+        encoding="utf-8",
+    )
+    (wiki / "c.md").write_text(
+        """---
+title: Root
+path: c.md
+weight: 3
+---
+body""",
+        encoding="utf-8",
+    )
+    (wiki / "skip.md").write_text(
+        """---
+title: Skip
+path: skip.md
+visible: false
+---
+ignore""",
+        encoding="utf-8",
+    )
+
+    auto_text = generate_sidebar(wiki)
+    auto_file = tmp_path / "sidebar" / "_auto_index.md"
+    auto_file.parent.mkdir()
+    auto_file.write_text(auto_text, encoding="utf-8")
+
+    sidebar = tmp_path / "_sidebar.md"
+    sidebar.write_text(
+        """<!-- AUTO-GENERATED BLOCK -->\n<!-- BEGIN: AUTO -->\nold\n<!-- END: AUTO -->\n\n<!-- BEGIN: MANUAL -->\nmanual\n<!-- END: MANUAL -->\n""",
+        encoding="utf-8",
+    )
+
+    update_sidebar(sidebar, auto_file)
+    lines = sidebar.read_text(encoding="utf-8").splitlines()
+    assert "old" not in lines
+    # manual block untouched
+    manual_index = lines.index("<!-- BEGIN: MANUAL -->")
+    assert lines[manual_index + 1] == "manual"
+    # check ordering and hierarchy
+    assert lines[2] == "* Seccion"
+    assert lines[3] == "  * Uno"
+    assert lines[4] == "    * [Tema B](b.md)"
+    assert lines[5] == "    * [Tema A](a.md)"
+    assert lines[6] == "* [Root](c.md)"

--- a/tools/sidebar_from_frontmatter.py
+++ b/tools/sidebar_from_frontmatter.py
@@ -1,0 +1,95 @@
+import argparse
+from pathlib import Path
+from typing import Dict, Any, List
+import yaml
+
+
+def _read_front_matter(path: Path) -> Dict[str, Any]:
+    """Return YAML front matter dict from a markdown file."""
+    if not path.exists():
+        return {}
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}
+    content = "\n".join(lines[1:end])
+    try:
+        data = yaml.safe_load(content) or {}
+    except Exception:
+        data = {}
+    return data
+
+
+def _collect_pages(root: Path) -> List[Dict[str, Any]]:
+    pages: List[Dict[str, Any]] = []
+    for md in root.rglob("*.md"):
+        if md.name == "_sidebar.md":
+            continue
+        meta = _read_front_matter(md)
+        if not meta:
+            continue
+        if meta.get("visible", True) is False:
+            continue
+        if meta.get("sidebar", True) is False:
+            continue
+        title = meta.get("title")
+        path = meta.get("path")
+        if not title or not path:
+            continue
+        pages.append(
+            {
+                "section_path": meta.get("section_path", ""),
+                "title": str(title),
+                "path": str(path),
+                "weight": int(meta.get("weight", 0)),
+            }
+        )
+    return pages
+
+
+def _build_tree(pages: List[Dict[str, Any]]) -> Dict[str, Any]:
+    root: Dict[str, Any] = {"subs": {}, "pages": []}
+    for page in pages:
+        node = root
+        sections = [s for s in str(page.get("section_path", "")).split("/") if s]
+        for sec in sections:
+            subs = node.setdefault("subs", {})
+            node = subs.setdefault(sec, {"subs": {}, "pages": []})
+        node.setdefault("pages", []).append(page)
+    return root
+
+
+def _render(node: Dict[str, Any], level: int = 0) -> List[str]:
+    lines: List[str] = []
+    indent = "  " * level
+    for sec, sub in sorted(node.get("subs", {}).items()):
+        lines.append(f"{indent}* {sec}")
+        lines.extend(_render(sub, level + 1))
+    pages = sorted(node.get("pages", []), key=lambda p: (p.get("weight", 0), p.get("title")))
+    for page in pages:
+        lines.append(f"{indent}* [{page['title']}]({page['path']})")
+    return lines
+
+
+def generate_sidebar(root: Path) -> str:
+    pages = _collect_pages(root)
+    tree = _build_tree(pages)
+    lines = _render(tree)
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wiki_path", type=Path)
+    args = parser.parse_args()
+    print(generate_sidebar(args.wiki_path))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tools/update_sidebar.py
+++ b/tools/update_sidebar.py
@@ -1,0 +1,35 @@
+import argparse
+from pathlib import Path
+from typing import List
+
+
+def update_sidebar(sidebar_path: Path, auto_index_path: Path) -> None:
+    """Replace AUTO block in sidebar with contents of auto index file."""
+    lines = sidebar_path.read_text(encoding="utf-8").splitlines()
+    auto_lines = auto_index_path.read_text(encoding="utf-8").splitlines()
+    start = end = None
+    for i, line in enumerate(lines):
+        if line.strip() == "<!-- BEGIN: AUTO -->":
+            start = i
+        elif line.strip() == "<!-- END: AUTO -->":
+            end = i
+            break
+    if start is None or end is None or start >= end:
+        raise RuntimeError("AUTO block not found in sidebar")
+    new_lines: List[str] = []
+    new_lines.extend(lines[: start + 1])
+    new_lines.extend(auto_lines)
+    new_lines.extend(lines[end:])
+    sidebar_path.write_text("\n".join(new_lines), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sidebar", type=Path)
+    parser.add_argument("auto_index", type=Path)
+    args = parser.parse_args()
+    update_sidebar(args.sidebar, args.auto_index)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -1,0 +1,9 @@
+<!-- AUTO-GENERATED BLOCK -->
+<!-- BEGIN: AUTO -->
+<!--INCLUDE: sidebar/_auto_index.md-->
+<!-- END: AUTO -->
+
+<!-- BEGIN: MANUAL -->
+* [🧑‍💻 Manual de sistemas](manual_sistemas/index.md)
+  * [Estructura funcional](manual_sistemas/estructura.md)
+<!-- END: MANUAL -->


### PR DESCRIPTION
## Summary
- generate modular sidebar block from YAML front matter metadata
- insert the auto block in `_sidebar.md` while preserving manual entries
- integrate auto sidebar generation in the `full` pipeline
- add tests for the new functionality

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7f2fb2548333a8a6e389cd0253c4