### PR TITLE
Fix wiki output path

### DIFF
--- a/src/wiki_documental/config.py
+++ b/src/wiki_documental/config.py
@@ -11,9 +11,11 @@ def load_config() -> dict:
     """Load configuration from config.yaml and ensure directories exist."""
     cfg_file = ROOT / "config.yaml"
     with cfg_file.open("r", encoding="utf-8") as f:
-        cfg = yaml.safe_load(f)
+        cfg = yaml.safe_load(f) or {}
 
     paths_cfg = cfg.get("paths", {})
+    if "wiki" not in paths_cfg:
+        paths_cfg["wiki"] = "wiki"
     for key, rel in paths_cfg.items():
         p = ROOT / rel
         p.mkdir(parents=True, exist_ok=True)

--- a/src/wiki_documental/processing/ingest.py
+++ b/src/wiki_documental/processing/ingest.py
@@ -179,6 +179,7 @@ def ingest_content(
         warn_missing_images(final_text, out_dir)
         with path.open("w", encoding="utf-8") as f:
             f.write(final_text)
+        print(f"Saved {path}")
 
     if unclassified:
         meta = _read_front_matter(out_dir / "99_unclassified.md")
@@ -222,3 +223,4 @@ def ingest_content(
         warn_missing_images(final_text, out_dir)
         with (out_dir / "99_unclassified.md").open("w", encoding="utf-8") as f:
             f.write(final_text)
+        print(f"Saved {out_dir / '99_unclassified.md'}")

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -1,0 +1,6 @@
+<!-- AUTO-GENERATED BLOCK -->
+<!-- BEGIN: AUTO -->
+<!-- END: AUTO -->
+
+<!-- BEGIN: MANUAL -->
+<!-- END: MANUAL -->


### PR DESCRIPTION
## Summary
- ensure wiki path is loaded with fallback in config
- log wiki directory and file conversions
- output converted docs to md using wiki path
- provide sidebar template to avoid pipeline crash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd13376088333a98e909c88397e46