### PR TITLE
Implement README autogeneration

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -182,13 +182,9 @@ def full() -> None:
             shutil.rmtree(dest)
         shutil.copytree(media_src, dest)
 
-    content_files = [f for f in wiki_dir.glob("*.md") if f.name not in ("_sidebar.md", "README.md")]
-    readme = wiki_dir / "README.md"
-    if not readme.exists() or not content_files:
-        readme.write_text(
-            "# Conocimiento Técnico Navantia\n\nEsta wiki fue generada automáticamente. Consulta el menú lateral para navegar.",
-            encoding="utf-8",
-        )
+    from .processing.readme_builder import build_readme
+
+    build_readme(wiki_dir, index_path=index_path, map_path=map_path)
 
     console.print(f"\N{check mark} Wiki generada correctamente en: {wiki_dir / 'index.html'}")
 

--- a/src/wiki_documental/processing/readme_builder.py
+++ b/src/wiki_documental/processing/readme_builder.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Tuple
+
+import yaml
+
+from .index_builder import build_index_from_map
+
+
+def _flatten(entries: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    flat: List[Dict[str, object]] = []
+    for entry in entries:
+        flat.append(entry)
+        flat.extend(_flatten(entry.get("children") or []))
+    return flat
+
+
+def _read_titles_from_index(index_path: Path) -> List[Tuple[str, str]]:
+    with index_path.open("r", encoding="utf-8") as f:
+        index_data: List[Dict[str, object]] = yaml.safe_load(f) or []
+    items: List[Tuple[str, str]] = []
+    for entry in _flatten(index_data):
+        slug = str(entry.get("slug"))
+        title = str(entry.get("title"))
+        identifier = str(entry.get("id", "")).replace(".", "-")
+        file_name = f"{identifier}_{slug}.md" if identifier else f"{slug}.md"
+        items.append((title, file_name))
+    return items
+
+
+def _read_titles_from_map(map_path: Path) -> List[Tuple[str, str]]:
+    with map_path.open("r", encoding="utf-8") as f:
+        map_data: List[Dict[str, object]] = yaml.safe_load(f) or []
+    index = build_index_from_map(map_data)
+    items: List[Tuple[str, str]] = []
+    for entry in _flatten(index):
+        slug = str(entry.get("slug"))
+        title = str(entry.get("title"))
+        identifier = str(entry.get("id", "")).replace(".", "-")
+        file_name = f"{identifier}_{slug}.md" if identifier else f"{slug}.md"
+        items.append((title, file_name))
+    return items
+
+
+def _read_titles_from_files(wiki_dir: Path) -> List[Tuple[str, str]]:
+    items: List[Tuple[str, str]] = []
+    for md in wiki_dir.glob("*.md"):
+        if md.name in {"README.md", "_sidebar.md"}:
+            continue
+        title = None
+        for line in md.read_text(encoding="utf-8").splitlines():
+            if line.startswith("#"):
+                title = line.lstrip("#").strip()
+                break
+        if not title:
+            title = md.stem
+        items.append((title, md.name))
+    return items
+
+
+def build_readme(wiki_dir: Path, index_path: Path | None = None, map_path: Path | None = None) -> None:
+    items: List[Tuple[str, str]] = []
+    if index_path and index_path.exists():
+        items = _read_titles_from_index(index_path)
+    elif map_path and map_path.exists():
+        items = _read_titles_from_map(map_path)
+    else:
+        items = _read_titles_from_files(wiki_dir)
+
+    # keep only files that actually exist
+    valid: List[Tuple[str, str]] = []
+    for title, file_name in items:
+        if (wiki_dir / file_name).exists():
+            valid.append((title, file_name))
+    items = valid
+
+    items.sort(key=lambda x: x[0].lower())
+
+    lines = [
+        "# Conocimiento Técnico Navantia",
+        "",
+        "Esta wiki fue generada automáticamente. Consulta el menú lateral para navegar.",
+        "",
+        "## Índice de documentos",
+        "",
+    ]
+    for title, file_name in items:
+        lines.append(f"* [{title}]({file_name})")
+
+    readme_path = wiki_dir / "README.md"
+    readme_path.write_text("\n".join(lines), encoding="utf-8")

--- a/tests/test_readme_builder.py
+++ b/tests/test_readme_builder.py
@@ -1,0 +1,37 @@
+import yaml
+from wiki_documental.processing.readme_builder import build_readme
+from wiki_documental.processing.index_builder import build_index_from_map
+
+
+def test_build_readme_from_files(tmp_path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "2_b.md").write_text("# B", encoding="utf-8")
+    (wiki / "1_a.md").write_text("# A", encoding="utf-8")
+
+    build_readme(wiki)
+    lines = (wiki / "README.md").read_text(encoding="utf-8").splitlines()
+    assert lines[-2:] == ["* [A](1_a.md)", "* [B](2_b.md)"]
+
+
+def test_build_readme_from_map(tmp_path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "1_b.md").write_text("# B", encoding="utf-8")
+    (wiki / "2_a.md").write_text("# A", encoding="utf-8")
+
+    map_data = [
+        {"level": 1, "title": "B", "slug": "b"},
+        {"level": 1, "title": "A", "slug": "a"},
+    ]
+    map_file = tmp_path / "map.yaml"
+    map_file.write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+
+    index_data = build_index_from_map(map_data)
+    index_file = tmp_path / "index.yaml"
+    index_file.write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
+
+    build_readme(wiki, index_path=index_file, map_path=map_file)
+    lines = (wiki / "README.md").read_text(encoding="utf-8").splitlines()
+    assert lines[-2:] == ["* [A](2_a.md)", "* [B](1_b.md)"]
+

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -1,0 +1,9 @@
+<!-- AUTO-GENERATED BLOCK -->
+<!-- BEGIN: AUTO -->
+<!--INCLUDE: sidebar/_auto_index.md-->
+<!-- END: AUTO -->
+
+<!-- BEGIN: MANUAL -->
+* [🧑‍💻 Manual de sistemas](manual_sistemas/index.md)
+  * [Estructura funcional](manual_sistemas/estructura.md)
+<!-- END: MANUAL -->


### PR DESCRIPTION
## Summary
- create `readme_builder` module to auto-generate wiki README
- invoke README generation from `wiki full`
- add tests covering builder logic
- restore sidebar template required by pipeline

## Testing
- `pip install python-docx PyYAML rich python-slugify tqdm "typer[all]" pytest pytest-cov`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd17152308333b8f52bd4e04695ec