### PR TITLE
Fix sidebar generation from map.yaml

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -313,9 +313,9 @@ def sidebar(
     )
 ) -> None:
     """Generate _sidebar.md for Docsify."""
-    index_path = cfg["paths"]["work"] / "index.yaml"
+    map_path = cfg["paths"]["work"] / "map.yaml"
     output_path = cfg["paths"]["wiki"] / "_sidebar.md"
-    build_sidebar(index_path, output_path, depth=depth)
+    build_sidebar(map_path, output_path, depth=depth)
     typer.echo("Sidebar generated")
 
 

--- a/src/wiki_documental/processing/sidebar.py
+++ b/src/wiki_documental/processing/sidebar.py
@@ -6,41 +6,35 @@ from typing import List, Dict
 import yaml
 
 
-def build_sidebar(index_path: Path, output_path: Path, depth: int = 1) -> None:
-    """Crea _sidebar.md jerárquico a partir de index.yaml.
+def build_sidebar(map_path: Path, output_path: Path, depth: int = 1) -> None:
+    """Generate ``_sidebar.md`` from ``map.yaml``.
 
     Parameters
     ----------
-    index_path : Path
-        Ruta al archivo ``index.yaml``.
+    map_path : Path
+        Path to ``map.yaml`` containing flat heading data.
     output_path : Path
-        Ruta del ``_sidebar.md`` a generar.
+        Destination ``_sidebar.md`` file.
     depth : int, optional
-        Profundidad máxima de títulos a incluir. ``1`` solo agrega los
-        encabezados de primer nivel.
+        Maximum heading level to include. ``1`` only adds level 1 headings.
     """
 
-    with index_path.open("r", encoding="utf-8") as f:
-        index_data: List[Dict[str, object]] = yaml.safe_load(f) or []
+    with map_path.open("r", encoding="utf-8") as f:
+        map_data: List[Dict[str, object]] = yaml.safe_load(f) or []
 
     lines: List[str] = []
     readme = output_path.parent / "README.md"
     if readme.exists():
         lines.append("* [Inicio](README.md)\n")
 
-    def add_entries(entries: List[Dict[str, object]], level: int) -> None:
-        indent = "  " * level
-        for entry in entries:
-            slug = entry.get("slug")
-            title = entry.get("title")
-            identifier = str(entry.get("id", "")).replace(".", "-")
-            file_name = f"{identifier}_{slug}.md"
-            lines.append(f"{indent}* [{title}]({file_name})\n")
-            children = entry.get("children") or []
-            if level + 1 < depth:
-                add_entries(children, level + 1)
-
-    add_entries(index_data, 0)
+    for entry in map_data:
+        level = int(entry.get("level", 1))
+        if level > depth:
+            continue
+        indent = "  " * (level - 1)
+        slug = entry.get("slug")
+        title = entry.get("title")
+        lines.append(f"{indent}* [{title}](/wiki/{slug}.md)\n")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", encoding="utf-8") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,11 +111,9 @@ def test_index_overwrite(tmp_path, monkeypatch):
 
 
 def test_sidebar_command(tmp_path, monkeypatch):
-    index = [
-        {"id": "1", "title": "A", "slug": "a", "children": []}
-    ]
+    data = [{"level": 1, "title": "A", "slug": "a"}]
     work = tmp_path
-    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    (work / "map.yaml").write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
     (work / "README.md").write_text("intro", encoding="utf-8")
@@ -125,27 +123,16 @@ def test_sidebar_command(tmp_path, monkeypatch):
     sidebar = work / "_sidebar.md"
     assert sidebar.exists()
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content == ["* [Inicio](README.md)", "* [A](1_a.md)"]
+    assert content == ["* [Inicio](README.md)", "* [A](/wiki/a.md)"]
 
 
 def test_sidebar_command_depth(tmp_path, monkeypatch):
-    index = [
-        {
-            "id": "1",
-            "title": "A",
-            "slug": "a",
-            "children": [
-                {
-                    "id": "1.1",
-                    "title": "B",
-                    "slug": "b",
-                    "children": [],
-                }
-            ],
-        }
+    data = [
+        {"level": 1, "title": "A", "slug": "a"},
+        {"level": 2, "title": "B", "slug": "b"},
     ]
     work = tmp_path
-    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    (work / "map.yaml").write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
     (work / "README.md").write_text("intro", encoding="utf-8")
@@ -154,5 +141,5 @@ def test_sidebar_command_depth(tmp_path, monkeypatch):
     assert result.exit_code == 0
     sidebar = work / "_sidebar.md"
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content[2] == "  * [B](1-1_b.md)"
+    assert content[2] == "  * [B](/wiki/b.md)"
 

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -2,67 +2,50 @@ import yaml
 from wiki_documental.processing.sidebar import build_sidebar
 
 
-def _sample_index():
+def _sample_map():
     return [
-        {
-            "id": "1",
-            "title": "Contexto",
-            "slug": "contexto",
-            "children": [
-                {
-                    "id": "1.1",
-                    "title": "Funcion",
-                    "slug": "funcion",
-                    "children": [
-                        {
-                            "id": "1.1.1",
-                            "title": "Detalles",
-                            "slug": "detalles",
-                            "children": [],
-                        }
-                    ],
-                }
-            ],
-        }
+        {"level": 1, "title": "Contexto", "slug": "contexto"},
+        {"level": 2, "title": "Funcion", "slug": "funcion"},
+        {"level": 3, "title": "Detalles", "slug": "detalles"},
     ]
 
 
 def test_build_sidebar_default_depth(tmp_path):
-    index = _sample_index()
-    index_path = tmp_path / "index.yaml"
-    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    data = _sample_map()
+    map_path = tmp_path / "map.yaml"
+    map_path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
     out_file = tmp_path / "_sidebar.md"
     (tmp_path / "README.md").write_text("intro", encoding="utf-8")
-    build_sidebar(index_path, out_file)
+    build_sidebar(map_path, out_file)
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines == [
         "* [Inicio](README.md)",
-        "* [Contexto](1_contexto.md)",
+        "* [Contexto](/wiki/contexto.md)",
     ]
 
 
 def test_build_sidebar_depth_3(tmp_path):
-    index = _sample_index()
-    index_path = tmp_path / "index.yaml"
-    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    data = _sample_map()
+    map_path = tmp_path / "map.yaml"
+    map_path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
     out_file = tmp_path / "_sidebar.md"
     (tmp_path / "README.md").write_text("intro", encoding="utf-8")
-    build_sidebar(index_path, out_file, depth=3)
+    build_sidebar(map_path, out_file, depth=3)
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines[0] == "* [Inicio](README.md)"
-    assert lines[1] == "* [Contexto](1_contexto.md)"
-    assert lines[2] == "  * [Funcion](1-1_funcion.md)"
-    assert lines[3] == "    * [Detalles](1-1-1_detalles.md)"
+    assert lines[1] == "* [Contexto](/wiki/contexto.md)"
+    assert lines[2] == "  * [Funcion](/wiki/funcion.md)"
+    assert lines[3] == "    * [Detalles](/wiki/detalles.md)"
 
 
 def test_build_sidebar_without_readme(tmp_path):
-    index = _sample_index()
-    index_path = tmp_path / "index.yaml"
-    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    data = _sample_map()
+    map_path = tmp_path / "map.yaml"
+    map_path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
     out_file = tmp_path / "_sidebar.md"
-    build_sidebar(index_path, out_file)
+    build_sidebar(map_path, out_file)
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
-    assert lines == ["* [Contexto](1_contexto.md)"]
+    assert lines == ["* [Contexto](/wiki/contexto.md)"]

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -1,0 +1,9 @@
+<!-- AUTO-GENERATED BLOCK -->
+<!-- BEGIN: AUTO -->
+<!--INCLUDE: sidebar/_auto_index.md-->
+<!-- END: AUTO -->
+
+<!-- BEGIN: MANUAL -->
+* [🧑‍💻 Manual de sistemas](manual_sistemas/index.md)
+  * [Estructura funcional](manual_sistemas/estructura.md)
+<!-- END: MANUAL -->


### PR DESCRIPTION
## Summary
- generate `_sidebar.md` using `map.yaml`
- reference wiki pages with slug-based paths
- restore sidebar template
- update tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd17804d083339fd99bf325e6b13e