### PR TITLE
Fix image path normalization

### DIFF
--- a/src/wiki_documental/processing/md_post.py
+++ b/src/wiki_documental/processing/md_post.py
@@ -16,19 +16,26 @@ def fix_image_links(text: str) -> str:
 
 
 def normalize_image_paths(md_text: str) -> str:
-    """Normalize image paths replacing backslashes and absolute drive paths."""
+    """Normalize image paths replacing backslashes and absolute drive paths.
+
+    Absolute drive paths like ``C:/foo/bar.png`` are rewritten to use a
+    relative ``../media/imagenes/`` prefix so the links remain portable.
+    """
 
     md_text = md_text.replace("\\", "/")
+
     def repl(match: re.Match[str]) -> str:
         path = match.group(1)
         name = Path(path).name.replace("\\", "/")
-        return f"(assets/media/{name})"
+        return f"(../media/imagenes/{name})"
 
     md_text = re.sub(r"\(([a-zA-Z]:[^)]+)\)", repl, md_text)
     return md_text
 
 
-ASSET_LINK_RE = re.compile(r"!\[[^\]]*\]\((assets/media/[^)]+)\)")
+ASSET_LINK_RE = re.compile(
+    r"!\[[^\]]*\]\(((?:assets/media|\.\./media/imagenes)/[^)]+)\)"
+)
 
 
 def warn_missing_images(text: str, wiki_dir: Path) -> None:

--- a/tests/test_md_post.py
+++ b/tests/test_md_post.py
@@ -56,3 +56,4 @@ def test_normalize_image_paths():
     assert '\\' not in result
     assert 'C:/' not in result
     assert 'assets/media/img.png' in result
+    assert '../media/imagenes/foo.png' in result

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -1,0 +1,2 @@
+<!-- BEGIN: AUTO -->
+<!-- END: AUTO -->


### PR DESCRIPTION
## Summary
- handle absolute Windows paths by rewriting to `../media/imagenes/`
- detect missing images using new pattern
- provide minimal `_sidebar.md` template
- update tests for new relative path behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd17ee60c833388e47bc1685d3f9c