### PR TITLE
Add index verification repair

### DIFF
--- a/src/wiki_documental/processing/verify_pre_ingest.py
+++ b/src/wiki_documental/processing/verify_pre_ingest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Any
 
 import yaml
+from .index_builder import build_index_from_map
 
 
 def _slug_level(slug: str) -> int:
@@ -52,3 +53,15 @@ def compare_map_index(map_path: Path, index_path: Path) -> Dict[str, List[str]]:
         "missing_in_index": sorted(map_slugs - index_slugs),
         "missing_in_map": sorted(index_slugs - map_slugs),
     }
+
+
+def repair_index(map_path: Path, index_path: Path) -> None:
+    """Rebuild index.yaml from map.yaml."""
+    if not map_path.exists():
+        return
+    with map_path.open("r", encoding="utf-8") as f:
+        map_data: List[Dict[str, Any]] = yaml.safe_load(f) or []
+    index_data = build_index_from_map(map_data)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    with index_path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(index_data, f, allow_unicode=True)

--- a/tests/test_verify_pre_ingest.py
+++ b/tests/test_verify_pre_ingest.py
@@ -73,3 +73,18 @@ def test_verify_cli_with_diffs(tmp_path, monkeypatch):
     result = runner.invoke(app, ["verify"])
     assert result.exit_code == 1
 
+
+def test_verify_cli_fix(tmp_path, monkeypatch):
+    map_data = [{"level": 1, "title": "A", "slug": "a"}]
+    index_data = [{"title": "B", "slug": "b", "children": []}]
+
+    work = tmp_path
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
+    monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
+
+    result = runner.invoke(app, ["verify", "--fix"])
+    assert result.exit_code == 0
+    index_result = yaml.safe_load((work / "index.yaml").read_text(encoding="utf-8"))
+    assert index_result[0]["slug"] == "a"
+

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -1,0 +1,7 @@
+<!-- AUTO-GENERATED BLOCK -->
+<!-- BEGIN: AUTO -->
+<!-- END: AUTO -->
+
+<!-- BEGIN: MANUAL -->
+* [Inicio](README.md)
+<!-- END: MANUAL -->


### PR DESCRIPTION
## Summary
- add `repair_index` helper to rebuild index from map
- support `--fix` in `verify` command to repair index.yaml
- ship default `_sidebar.md` template for full pipeline
- test verifying CLI with fix option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd1861aec8333aa1528e3d614e6cf