### PR TITLE
Fix absolute paths in image tags

### DIFF
--- a/tests/test_md_post.py
+++ b/tests/test_md_post.py
@@ -57,3 +57,17 @@ def test_normalize_image_paths():
     assert 'C:/' not in result
     assert 'assets/media/img.png' in result
     assert '../media/imagenes/foo.png' in result
+
+
+def test_fix_image_links_html():
+    text = '<img src="media/img.png" /> <img src="C:/path/to/assets/media/x.png" />'
+    result = fix_image_links(text)
+    assert '<img src="assets/media/img.png"' in result
+    assert '<img src="assets/media/x.png"' in result
+
+
+def test_normalize_image_paths_html():
+    text = '<img src="C:/temp/foo.png" />'
+    result = normalize_image_paths(text)
+    assert 'C:/' not in result
+    assert '<img src="assets/media/foo.png"' in result


### PR DESCRIPTION
## Summary
- make `fix_image_links` rewrite `<img src>` tags
- update `normalize_image_paths` for HTML images
- test HTML cases in `test_md_post`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cee8cb7f883339d67b8c7d3d857f8