### PR TITLE
fix(nav): generate relative links in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Generate a `_sidebar.md` file for Docsify based on `index.yaml`.
 Options:
 
 - `--depth` – maximum heading level to include in the sidebar (default `1`).
+- `--relative-links/--absolute-links` – generate links without the `/wiki/` prefix (default `--relative-links`).
 
 ### Branding
 

--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -83,6 +83,11 @@ def full(
         help="Maximum heading level to include in _sidebar.md",
         show_default=True,
     ),
+    relative_links: bool = typer.Option(
+        True,
+        "--relative-links/--absolute-links",
+        help="Generate sidebar links as relative paths",
+    ),
     skip_verify: Annotated[bool, typer.Option("--skip-verify")] = False,
 ) -> None:
     """Run full wiki generation pipeline."""
@@ -172,7 +177,7 @@ def full(
 
     console.print("[bold]Generating sidebar...[/bold]")
     sidebar_dest = wiki_dir / "_sidebar.md"
-    build_sidebar(index_path, sidebar_dest, depth=depth)
+    build_sidebar(index_path, sidebar_dest, depth=depth, relative_links=relative_links)
 
     media_src = md_raw_dir / "media"
     if media_src.exists():
@@ -326,13 +331,18 @@ def ingest(file: Path) -> None:
 def sidebar(
     depth: int = typer.Option(
         1, "--depth", "-d", help="Maximum heading level to include"
-    )
+    ),
+    relative_links: bool = typer.Option(
+        True,
+        "--relative-links/--absolute-links",
+        help="Generate sidebar links as relative paths",
+    ),
 ) -> None:
     """Generate _sidebar.md for Docsify."""
     map_path = cfg["paths"]["work"] / "map.yaml"
     wiki_dir = cfg.get("paths", {}).get("wiki", Path("wiki"))
     output_path = wiki_dir / "_sidebar.md"
-    build_sidebar(map_path, output_path, depth=depth)
+    build_sidebar(map_path, output_path, depth=depth, relative_links=relative_links)
     typer.echo("Sidebar generated")
 
 

--- a/src/wiki_documental/processing/sidebar.py
+++ b/src/wiki_documental/processing/sidebar.py
@@ -6,7 +6,13 @@ from typing import List, Dict
 import yaml
 
 
-def build_sidebar(map_path: Path, output_path: Path, depth: int = 1) -> None:
+def build_sidebar(
+    map_path: Path,
+    output_path: Path,
+    depth: int = 1,
+    *,
+    relative_links: bool = True,
+) -> None:
     """Generate ``_sidebar.md`` from ``map.yaml``.
 
     Parameters
@@ -17,6 +23,8 @@ def build_sidebar(map_path: Path, output_path: Path, depth: int = 1) -> None:
         Destination ``_sidebar.md`` file.
     depth : int, optional
         Maximum heading level to include. ``1`` only adds level 1 headings.
+    relative_links : bool, optional
+        Generate links without the ``/wiki/`` prefix for offline compatibility.
     """
 
     with map_path.open("r", encoding="utf-8") as f:
@@ -34,7 +42,8 @@ def build_sidebar(map_path: Path, output_path: Path, depth: int = 1) -> None:
         indent = "  " * (level - 1)
         slug = entry.get("slug")
         title = entry.get("title")
-        lines.append(f"{indent}* [{title}](/wiki/{slug}.md)\n")
+        link = f"{slug}.md" if relative_links else f"/wiki/{slug}.md"
+        lines.append(f"{indent}* [{title}]({link})\n")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", encoding="utf-8") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ def test_full_calls_ensure_pandoc(monkeypatch, tmp_path):
     monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
 
-    def fake_build_sidebar(_idx, _out, depth=1):
+    def fake_build_sidebar(_idx, _out, depth=1, relative_links=True):
         sidebar_depth["value"] = depth
         (_out).write_text("sidebar", encoding="utf-8")
 
@@ -130,7 +130,7 @@ def test_sidebar_command(tmp_path, monkeypatch):
     sidebar = work / "_sidebar.md"
     assert sidebar.exists()
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content == ["* [Inicio](README.md)", "* [A](/wiki/a.md)"]
+    assert content == ["* [Inicio](README.md)", "* [A](a.md)"]
 
 
 def test_sidebar_command_depth(tmp_path, monkeypatch):
@@ -148,13 +148,13 @@ def test_sidebar_command_depth(tmp_path, monkeypatch):
     assert result.exit_code == 0
     sidebar = work / "_sidebar.md"
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content[2] == "  * [B](/wiki/b.md)"
+    assert content[2] == "  * [B](b.md)"
 
 
 def test_full_depth_option(monkeypatch, tmp_path):
     sidebar_depth = {"value": None}
 
-    def fake_build_sidebar(_idx, _out, depth=1):
+    def fake_build_sidebar(_idx, _out, depth=1, relative_links=True):
         sidebar_depth["value"] = depth
         (_out).write_text("sidebar", encoding="utf-8")
 

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -21,7 +21,7 @@ def test_build_sidebar_default_depth(tmp_path):
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines == [
         "* [Inicio](README.md)",
-        "* [Contexto](/wiki/contexto.md)",
+        "* [Contexto](contexto.md)",
     ]
 
 
@@ -35,9 +35,9 @@ def test_build_sidebar_depth_3(tmp_path):
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines[0] == "* [Inicio](README.md)"
-    assert lines[1] == "* [Contexto](/wiki/contexto.md)"
-    assert lines[2] == "  * [Funcion](/wiki/funcion.md)"
-    assert lines[3] == "    * [Detalles](/wiki/detalles.md)"
+    assert lines[1] == "* [Contexto](contexto.md)"
+    assert lines[2] == "  * [Funcion](funcion.md)"
+    assert lines[3] == "    * [Detalles](detalles.md)"
 
 
 def test_build_sidebar_without_readme(tmp_path):
@@ -48,4 +48,4 @@ def test_build_sidebar_without_readme(tmp_path):
     build_sidebar(map_path, out_file)
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
-    assert lines == ["* [Contexto](/wiki/contexto.md)"]
+    assert lines == ["* [Contexto](contexto.md)"]


### PR DESCRIPTION
## Summary
- add `relative_links` option to `build_sidebar`
- expose `--relative-links/--absolute-links` in CLI commands
- default to relative links in `_sidebar.md`
- document new flag in README
- update tests for relative paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cee97f3e4833380b979697349513e