### PR TITLE
fix(nav): use front-matter path directly for sidebar links

### DIFF
--- a/tools/sidebar_from_frontmatter.py
+++ b/tools/sidebar_from_frontmatter.py
@@ -39,11 +39,12 @@ def _collect_pages(root: Path) -> List[Dict[str, Any]]:
         if meta.get("sidebar", True) is False:
             continue
         title = meta.get("title")
-        raw_path = meta.get("path")
-        path = Path(str(raw_path)).name if raw_path else None
+        path = meta.get("path")
         if not title or not path:
+            if not path:
+                print(f"Missing 'path' in {md}")
             continue
-        if path == "99_unclassified.md":
+        if str(path) == "99_unclassified.md":
             continue
         pages.append(
             {


### PR DESCRIPTION
## Summary
- read the path from front-matter and warn when missing
- rely on the literal path when generating sidebar links

## Testing
- `poetry run pytest -q`
- `poetry run wiki full --skip-verify`


------
https://chatgpt.com/codex/tasks/task_e_684cfcfe483883338d64ee51e2f45bb2