### PR TITLE
Refactor config and add safe slug

### DIFF
--- a/src/wiki_documental/cli.py
+++ b/src/wiki_documental/cli.py
@@ -7,7 +7,8 @@ from shutil import rmtree
 from rich.console import Console
 
 from . import ensure_pandoc, __version__
-from .config import cfg
+from . import config
+cfg = config.cfg
 from .processing.normalize_docx import normalize_styles
 from .processing.docx_to_md import convert_docx_to_md
 from .processing.headings_map import build_headings_map, save_map_yaml
@@ -70,6 +71,7 @@ def main(
     )
 ):
     """Wiki Documental CLI."""
+    config.init_paths()
     return
 
 

--- a/src/wiki_documental/config.py
+++ b/src/wiki_documental/config.py
@@ -4,12 +4,12 @@ from pathlib import Path
 import yaml
 
 
-ROOT = Path(__file__).resolve().parents[2]
+BASE_DIR = Path(__file__).resolve().parents[2]
 
 
 def load_config() -> dict:
-    """Load configuration from config.yaml and ensure directories exist."""
-    cfg_file = ROOT / "config.yaml"
+    """Load configuration from config.yaml."""
+    cfg_file = BASE_DIR / "config.yaml"
     with cfg_file.open("r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
 
@@ -17,11 +17,15 @@ def load_config() -> dict:
     if "wiki" not in paths_cfg:
         paths_cfg["wiki"] = "wiki"
     for key, rel in paths_cfg.items():
-        p = ROOT / rel
-        p.mkdir(parents=True, exist_ok=True)
-        paths_cfg[key] = p
+        paths_cfg[key] = BASE_DIR / rel
     cfg["paths"] = paths_cfg
     return cfg
+
+
+def init_paths() -> None:
+    """Create directory structure defined in ``cfg``."""
+    for p in cfg.get("paths", {}).values():
+        Path(p).mkdir(parents=True, exist_ok=True)
 
 
 cfg = load_config()

--- a/src/wiki_documental/processing/headings_map.py
+++ b/src/wiki_documental/processing/headings_map.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List, Dict
 
 import yaml
-from slugify import slugify
+from ..utils import safe_slug
 
 NUMBER_RE = re.compile(r"^\d+(\.\d+)*\s+")
 
@@ -21,6 +21,7 @@ def build_headings_map(
 ) -> List[Dict[str, str | int]]:
     """Return a list of heading data dictionaries."""
     map_data: List[Dict[str, str | int]] = []
+    used_slugs: set[str] = set()
     for md_file in md_folder.rglob("*.md"):
         with md_file.open("r", encoding="utf-8") as f:
             for line in f:
@@ -30,11 +31,13 @@ def build_headings_map(
                     title = m.group(2).strip()
                     if strip_numbers and level >= from_level:
                         title = NUMBER_RE.sub("", title)
+                    slug = safe_slug(title, used_slugs, max_len=60)
+                    used_slugs.add(slug)
                     map_data.append(
                         {
                             "level": level,
                             "title": title,
-                            "slug": slugify(title, lowercase=True, max_length=60),
+                            "slug": slug,
                         }
                     )
     return map_data

--- a/src/wiki_documental/utils/__init__.py
+++ b/src/wiki_documental/utils/__init__.py
@@ -1,0 +1,22 @@
+import hashlib
+import re
+import unicodedata
+
+__all__ = ["safe_slug", "ensure_pandoc"]
+
+from .system import ensure_pandoc
+
+
+def safe_slug(title: str, existing: set[str], max_len: int = 50) -> str:
+    """Return a unique, ASCII-only slug for ``title``.
+
+    Collisions are resolved by appending a short hash suffix.
+    """
+    normalized = unicodedata.normalize("NFKD", title)
+    normalized = "".join(c for c in normalized if not unicodedata.combining(c))
+    slug = re.sub(r"[^a-z0-9]+", "-", normalized.lower()).strip("-")
+    slug = slug[:max_len].rstrip("-")
+    if slug in existing:
+        h = hashlib.sha1(title.encode("utf-8")).hexdigest()[:4]
+        slug = f"{slug}-{h}"
+    return slug

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,7 @@ def test_full_calls_ensure_pandoc(monkeypatch, tmp_path):
     monkeypatch.setattr("subprocess.run", fake_run)
     monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
 
     def fake_build_sidebar(_idx, _out, depth=1, relative_links=True):
         sidebar_depth["value"] = depth
@@ -78,6 +79,7 @@ def test_normalize_command(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "wiki_documental.cli.cfg", {"paths": {"work": tmp_path}}
     )
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": {"work": tmp_path}})
     result = runner.invoke(app, ["normalize", str(sample)])
     assert result.exit_code == 0
     assert (tmp_path / "normalized" / sample.name).exists()
@@ -90,6 +92,7 @@ def test_map_command(tmp_path, monkeypatch):
     md_folder.mkdir()
     (md_folder / "sample.md").write_text("# Title\n", encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": tmp_path}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": {"work": tmp_path}})
     result = runner.invoke(app, ["map"])
     assert result.exit_code == 0
     map_file = tmp_path / "map.yaml"
@@ -109,6 +112,7 @@ def test_index_overwrite(tmp_path, monkeypatch):
     (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
     (work / "index.yaml").write_text("old", encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": {"work": work}})
 
     result = runner.invoke(app, ["index", "--overwrite"])
     assert result.exit_code == 0
@@ -123,6 +127,7 @@ def test_sidebar_command(tmp_path, monkeypatch):
     (work / "map.yaml").write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths})
     (work / "README.md").write_text("intro", encoding="utf-8")
 
     result = runner.invoke(app, ["sidebar"])
@@ -142,6 +147,7 @@ def test_sidebar_command_depth(tmp_path, monkeypatch):
     (work / "map.yaml").write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths})
     (work / "README.md").write_text("intro", encoding="utf-8")
 
     result = runner.invoke(app, ["sidebar", "--depth", "2"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import wiki_documental.config as config
 
 
-def test_load_config_creates_directories(tmp_path, monkeypatch):
+def test_load_config_and_init_paths(tmp_path, monkeypatch):
     root = tmp_path / "project"
     root.mkdir()
     (root / "src/wiki_documental").mkdir(parents=True)
@@ -23,8 +23,14 @@ def test_load_config_creates_directories(tmp_path, monkeypatch):
     fake_file = root / "src/wiki_documental/config.py"
     fake_file.write_text("", encoding="utf-8")
     monkeypatch.setattr(config, "__file__", str(fake_file))
+    monkeypatch.setattr(config, "BASE_DIR", root)
 
     cfg = config.load_config()
     assert isinstance(cfg["paths"]["originals"], Path)
+    for path in cfg["paths"].values():
+        assert not path.exists()
+
+    config.cfg = cfg
+    config.init_paths()
     for path in cfg["paths"].values():
         assert path.exists()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -51,6 +51,7 @@ def test_package_static(tmp_path, monkeypatch):
     monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
 
     monkeypatch.chdir(tmp_path)
     import sys

--- a/tests/test_pipeline_doc_sources.py
+++ b/tests/test_pipeline_doc_sources.py
@@ -54,6 +54,10 @@ def test_full_multiple_doc_sources(tmp_path, monkeypatch):
         "wiki_documental.cli.cfg",
         {"paths": paths, "options": {"cutoff_similarity": 0.5}},
     )
+    monkeypatch.setattr(
+        "wiki_documental.config.cfg",
+        {"paths": paths, "options": {"cutoff_similarity": 0.5}},
+    )
 
     result = runner.invoke(app, ["full"])
     assert result.exit_code == 0

--- a/tests/test_pipeline_full.py
+++ b/tests/test_pipeline_full.py
@@ -38,6 +38,8 @@ def test_pipeline_full(tmp_path, monkeypatch):
     monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
 
     result = runner.invoke(app, ["full"])
     assert result.exit_code == 0

--- a/tests/test_pipeline_verify.py
+++ b/tests/test_pipeline_verify.py
@@ -61,6 +61,8 @@ def test_full_skip_verify(tmp_path, monkeypatch):
     monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
 
     result = runner.invoke(app, ["full", "--skip-verify"])
     assert result.exit_code == 0

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -42,6 +42,7 @@ def test_reclassify_unclassified(tmp_path):
 def test_reclassify_cli(tmp_path, monkeypatch):
     work, wiki, unclassified = _setup(tmp_path)
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work, "wiki": wiki}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": {"work": work, "wiki": wiki}})
     result = runner.invoke(app, ["reclassify", "--threshold", "0.3"])
     assert result.exit_code == 0
     assert "add1" in (wiki / "1_first.md").read_text(encoding="utf-8")

--- a/tests/test_reset_work_dir.py
+++ b/tests/test_reset_work_dir.py
@@ -45,6 +45,7 @@ def test_reset_work_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("wiki_documental.processing.docx_to_md.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": paths, "options": {"cutoff_similarity": 0.5}})
 
     result = runner.invoke(app, ["full"])
     assert result.exit_code == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+from wiki_documental.utils import safe_slug
+
+
+def test_safe_slug_uniqueness():
+    existing = set()
+    s1 = safe_slug("Título", existing)
+    existing.add(s1)
+    s2 = safe_slug("Título", existing)
+    assert s1 != s2
+    assert s2.startswith(s1 + "-")
+
+
+def test_safe_slug_clean():
+    slug = safe_slug("Árbol / Fase", set())
+    assert slug == "arbol-fase"

--- a/tests/test_verify_pre_ingest.py
+++ b/tests/test_verify_pre_ingest.py
@@ -58,6 +58,7 @@ def test_verify_cli(tmp_path, monkeypatch):
     (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
     (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": {"work": work}})
 
     result = runner.invoke(app, ["verify"])
     assert result.exit_code == 0
@@ -72,6 +73,7 @@ def test_verify_cli_with_diffs(tmp_path, monkeypatch):
     (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
     (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": {"work": work}})
 
     result = runner.invoke(app, ["verify"])
     assert result.exit_code == 1
@@ -85,6 +87,7 @@ def test_verify_cli_fix(tmp_path, monkeypatch):
     (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
     (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
     monkeypatch.setattr("wiki_documental.cli.cfg", {"paths": {"work": work}})
+    monkeypatch.setattr("wiki_documental.config.cfg", {"paths": {"work": work}})
 
     result = runner.invoke(app, ["verify", "--fix"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- refactor config so importing it doesn't create directories
- update CLI to initialize paths via config.init_paths()
- implement `safe_slug` for unique slug generation
- use `safe_slug` when building headings map
- adjust tests for new behaviour and add tests for `safe_slug`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d0c190f3c83338191335e866fd5d2