### PR TITLE
Fix ruff lint violations

### DIFF
--- a/src/wiki_documental/__init__.py
+++ b/src/wiki_documental/__init__.py
@@ -1,8 +1,8 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from .utils.system import ensure_pandoc
-from .config import cfg  # noqa: F401
+from .utils.system import ensure_pandoc as ensure_pandoc
+
 
 try:  # pragma: no cover - best effort when package isn't installed
     __version__ = version("wiki_documental")

--- a/src/wiki_documental/processing/headings_map.py
+++ b/src/wiki_documental/processing/headings_map.py
@@ -50,9 +50,9 @@ def save_map_yaml(map_data: List[Dict[str, str | int]], path: Path) -> None:
     for item in map_data:
         level = int(item.get("level", 1))
         counters[level] = counters.get(level, 0) + 1
-        for l in list(counters.keys()):
-            if l > level:
-                del counters[l]
+        for level_key in list(counters.keys()):
+            if level_key > level:
+                del counters[level_key]
         id_parts = [str(counters[i]) for i in range(1, level + 1) if i in counters]
         enriched.append({"id": ".".join(id_parts), **item})
 

--- a/src/wiki_documental/processing/index_builder.py
+++ b/src/wiki_documental/processing/index_builder.py
@@ -22,9 +22,9 @@ def build_index_from_map(map_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]
         if not title_clean.strip():
             continue
         counters[level] = counters.get(level, 0) + 1
-        for l in list(counters.keys()):
-            if l > level:
-                del counters[l]
+        for level_key in list(counters.keys()):
+            if level_key > level:
+                del counters[level_key]
         id_parts = [str(counters[i]) for i in range(1, level + 1) if i in counters]
         entry = {
             "id": ".".join(id_parts),

--- a/src/wiki_documental/processing/md_post.py
+++ b/src/wiki_documental/processing/md_post.py
@@ -17,7 +17,7 @@ def fix_image_links(text: str) -> str:
 
     def repl(match: re.Match[str]) -> str:
         original = match.group(0)
-        quote = match.group(1)
+        _quote = match.group(1)
         src = match.group(2)
         new_src = src.replace("\\", "/").replace("file://", "")
         if "assets/media/" in new_src:


### PR DESCRIPTION
## Summary
- clean up unused imports and reorder imports
- re-export `ensure_pandoc` and remove unused `cfg`
- rename loop variables to `level_key`
- rename unused local variable in `md_post`

## Testing
- `ruff check src/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d1a4661a08333b1af8b31cd559d7f