### PR TITLE
Implement automatic sidebar generation

### DIFF
--- a/src/wiki/processing/sidebar.py
+++ b/src/wiki/processing/sidebar.py
@@ -1,51 +1,24 @@
-from __future__ import annotations
-
-from pathlib import Path
-from typing import List, Dict
-
 import yaml
+from pathlib import Path
 
 
-def build_sidebar(index_path: Path, output_path: Path, depth: int = 1) -> None:
-    """Crea _sidebar.md jerárquico a partir de index.yaml.
+def build_sidebar(map_path: Path, wiki_dir: Path, absolute_links: bool = False) -> None:
+    """Generate a Docsify sidebar from map.yaml."""
+    with map_path.open(encoding="utf-8") as f:
+        headings = yaml.safe_load(f) or []
 
-    Parameters
-    ----------
-    index_path : Path
-        Ruta al archivo ``index.yaml``.
-    output_path : Path
-        Ruta del ``_sidebar.md`` a generar.
-    depth : int, optional
-        Profundidad máxima de títulos a incluir. ``1`` solo agrega los
-        encabezados de primer nivel.
-    """
+    lines = []
+    for item in headings:
+        level = int(item.get("level", 1))
+        title = item.get("title", "")
+        filename = item.get("filename")
+        if not filename:
+            continue
+        link = f"/wiki/{filename}" if absolute_links else filename
+        indent = "  " * (level - 1)
+        lines.append(f"{indent}* [{title}]({link})")
 
-    with index_path.open("r", encoding="utf-8") as f:
-        index_data: List[Dict[str, object]] = yaml.safe_load(f) or []
-
-    lines: List[str] = []
-    readme = output_path.parent / "README.md"
-    if readme.exists():
-        lines.append("* [Inicio](README.md)\n")
-
-    def add_entries(entries: List[Dict[str, object]], level: int) -> None:
-        indent = "  " * level
-        for entry in entries:
-            slug = entry.get("slug")
-            title = entry.get("title")
-            identifier = str(entry.get("id", ""))
-            parts = identifier.split(".")
-            doc_id = parts[0]
-            section_id = "-".join(parts[1:])
-            prefix = f"{doc_id}_{section_id}" if section_id else doc_id
-            file_name = f"{prefix}_{slug}.md"
-            lines.append(f"{indent}* [{title}]({file_name})\n")
-            children = entry.get("children") or []
-            if level + 1 < depth:
-                add_entries(children, level + 1)
-
-    add_entries(index_data, 0)
-
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as f:
-        f.writelines(lines)
+    sidebar_path = wiki_dir / "_sidebar.md"
+    sidebar_path.parent.mkdir(parents=True, exist_ok=True)
+    with sidebar_path.open("w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,48 +111,34 @@ def test_index_overwrite(tmp_path, monkeypatch):
 
 
 def test_sidebar_command(tmp_path, monkeypatch):
-    index = [
-        {"id": "1", "title": "A", "slug": "a", "children": []}
+    map_data = [
+        {"level": 1, "title": "A", "filename": "1_a.md"},
     ]
     work = tmp_path
-    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
-    (work / "README.md").write_text("intro", encoding="utf-8")
 
     result = runner.invoke(app, ["sidebar"])
     assert result.exit_code == 0
     sidebar = work / "_sidebar.md"
     assert sidebar.exists()
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content == ["* [Inicio](README.md)", "* [A](1_a.md)"]
+    assert content == ["* [A](1_a.md)"]
 
 
-def test_sidebar_command_depth(tmp_path, monkeypatch):
-    index = [
-        {
-            "id": "1",
-            "title": "A",
-            "slug": "a",
-            "children": [
-                {
-                    "id": "1.1",
-                    "title": "B",
-                    "slug": "b",
-                    "children": [],
-                }
-            ],
-        }
+def test_sidebar_command_absolute(tmp_path, monkeypatch):
+    map_data = [
+        {"level": 1, "title": "A", "filename": "1_a.md"},
     ]
     work = tmp_path
-    (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
-    (work / "README.md").write_text("intro", encoding="utf-8")
 
-    result = runner.invoke(app, ["sidebar", "--depth", "2"])
+    result = runner.invoke(app, ["--absolute-links", "sidebar"])
     assert result.exit_code == 0
     sidebar = work / "_sidebar.md"
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content[2] == "  * [B](1_1_b.md)"
+    assert content == ["* [A](/wiki/1_a.md)"]
 

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -1,68 +1,25 @@
-import yaml
 from wiki.processing.sidebar import build_sidebar
+from pathlib import Path
 
 
-def _sample_index():
-    return [
-        {
-            "id": "1",
-            "title": "Contexto",
-            "slug": "contexto",
-            "children": [
-                {
-                    "id": "1.1",
-                    "title": "Funcion",
-                    "slug": "funcion",
-                    "children": [
-                        {
-                            "id": "1.1.1",
-                            "title": "Detalles",
-                            "slug": "detalles",
-                            "children": [],
-                        }
-                    ],
-                }
-            ],
-        }
-    ]
+def test_sidebar_generation(tmp_path):
+    map_file = tmp_path / "map.yaml"
+    map_file.write_text(
+        """
+- level: 1
+  title: Introducción
+  filename: 1_1-introduccion.md
+- level: 2
+  title: Alcance
+  filename: 1_2-alcance.md
+""",
+        encoding="utf-8",
+    )
 
+    wiki_dir = tmp_path / "wiki"
+    wiki_dir.mkdir()
+    build_sidebar(map_file, wiki_dir, absolute_links=False)
 
-def test_build_sidebar_default_depth(tmp_path):
-    index = _sample_index()
-    index_path = tmp_path / "index.yaml"
-    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
-    out_file = tmp_path / "_sidebar.md"
-    (tmp_path / "README.md").write_text("intro", encoding="utf-8")
-    build_sidebar(index_path, out_file)
-
-    lines = out_file.read_text(encoding="utf-8").splitlines()
-    assert lines == [
-        "* [Inicio](README.md)",
-        "* [Contexto](1_contexto.md)",
-    ]
-
-
-def test_build_sidebar_depth_3(tmp_path):
-    index = _sample_index()
-    index_path = tmp_path / "index.yaml"
-    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
-    out_file = tmp_path / "_sidebar.md"
-    (tmp_path / "README.md").write_text("intro", encoding="utf-8")
-    build_sidebar(index_path, out_file, depth=3)
-
-    lines = out_file.read_text(encoding="utf-8").splitlines()
-    assert lines[0] == "* [Inicio](README.md)"
-    assert lines[1] == "* [Contexto](1_contexto.md)"
-    assert lines[2] == "  * [Funcion](1_1_funcion.md)"
-    assert lines[3] == "    * [Detalles](1_1-1_detalles.md)"
-
-
-def test_build_sidebar_without_readme(tmp_path):
-    index = _sample_index()
-    index_path = tmp_path / "index.yaml"
-    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
-    out_file = tmp_path / "_sidebar.md"
-    build_sidebar(index_path, out_file)
-
-    lines = out_file.read_text(encoding="utf-8").splitlines()
-    assert lines == ["* [Contexto](1_contexto.md)"]
+    sidebar_content = (wiki_dir / "_sidebar.md").read_text(encoding="utf-8")
+    assert "* [Introducción](1_1-introduccion.md)" in sidebar_content
+    assert "  * [Alcance](1_2-alcance.md)" in sidebar_content


### PR DESCRIPTION
## Summary
- simplify sidebar builder to read from `map.yaml`
- support absolute links for docsify
- expose global `--absolute-links` CLI option
- update `full` and `sidebar` commands to use new sidebar builder
- revise sidebar unit tests and CLI tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2698669c8333b2cc54ed696711a8