### PR TITLE
Add filenames to heading map

### DIFF
--- a/src/wiki/processing/headings_map.py
+++ b/src/wiki/processing/headings_map.py
@@ -24,7 +24,8 @@ def build_headings_map(
     """Return a list of heading data dictionaries."""
     map_data: List[Dict[str, str | int]] = []
     used_slugs.clear()
-    for md_file in md_folder.rglob("*.md"):
+    counters: dict[int, int] = {}
+    for md_file in sorted(md_folder.rglob("*.md")):
         with md_file.open("r", encoding="utf-8") as f:
             for line in f:
                 m = HEADING_RE.match(line.strip())
@@ -33,28 +34,59 @@ def build_headings_map(
                     title = m.group(2).strip()
                     if strip_numbers and level >= from_level:
                         title = NUMBER_RE.sub("", title)
+
+                    counters[level] = counters.get(level, 0) + 1
+                    for l in list(counters.keys()):
+                        if l > level:
+                            del counters[l]
+                    id_parts = [str(counters[i]) for i in range(1, level + 1) if i in counters]
+                    identifier = ".".join(id_parts)
+
+                    slug = safe_slug(title, used_slugs)
+
+                    parts = identifier.split(".")
+                    doc_id = parts[0]
+                    section_id = "-".join(parts[1:])
+                    prefix = f"{doc_id}_{section_id}" if section_id else doc_id
+                    filename = f"{prefix}_{slug}.md"
+
                     map_data.append(
                         {
+                            "id": identifier,
                             "level": level,
                             "title": title,
-                            "slug": safe_slug(title, used_slugs),
+                            "slug": slug,
+                            "filename": filename,
                         }
                     )
     return map_data
 
 
 def save_map_yaml(map_data: List[Dict[str, str | int]], path: Path) -> None:
-    """Save map data to YAML file with id/slug pairs."""
+    """Save map data to YAML file."""
     counters: dict[int, int] = {}
     enriched: List[Dict[str, str | int]] = []
     for item in map_data:
         level = int(item.get("level", 1))
-        counters[level] = counters.get(level, 0) + 1
-        for l in list(counters.keys()):
-            if l > level:
-                del counters[l]
-        id_parts = [str(counters[i]) for i in range(1, level + 1) if i in counters]
-        enriched.append({"id": ".".join(id_parts), **item})
+        identifier = item.get("id")
+        if identifier is None:
+            counters[level] = counters.get(level, 0) + 1
+            for l in list(counters.keys()):
+                if l > level:
+                    del counters[l]
+            id_parts = [str(counters[i]) for i in range(1, level + 1) if i in counters]
+            identifier = ".".join(id_parts)
+
+        slug = str(item.get("slug", ""))
+        filename = item.get("filename")
+        if not filename and identifier and slug:
+            parts = str(identifier).split(".")
+            doc_id = parts[0]
+            section_id = "-".join(parts[1:])
+            prefix = f"{doc_id}_{section_id}" if section_id else doc_id
+            filename = f"{prefix}_{slug}.md"
+
+        enriched.append({"id": identifier, **item, "filename": filename})
 
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,7 @@ def test_map_command(tmp_path, monkeypatch):
     data = yaml.safe_load(map_file.read_text(encoding="utf-8"))
     assert data[0]["slug"] == "title"
     assert data[0]["id"] == "1"
+    assert data[0]["filename"] == "1_title.md"
 
 
 def test_index_overwrite(tmp_path, monkeypatch):

--- a/tests/test_headings_map.py
+++ b/tests/test_headings_map.py
@@ -8,9 +8,27 @@ def test_build_headings_map(tmp_path):
     md_file.write_text("# H1\n## H2\n### H3\n", encoding="utf-8")
     result = build_headings_map(md_folder)
     assert result == [
-        {"level": 1, "title": "H1", "slug": "h1"},
-        {"level": 2, "title": "H2", "slug": "h2"},
-        {"level": 3, "title": "H3", "slug": "h3"},
+        {
+            "id": "1",
+            "level": 1,
+            "title": "H1",
+            "slug": "h1",
+            "filename": "1_h1.md",
+        },
+        {
+            "id": "1.1",
+            "level": 2,
+            "title": "H2",
+            "slug": "h2",
+            "filename": "1_1_h2.md",
+        },
+        {
+            "id": "1.1.1",
+            "level": 3,
+            "title": "H3",
+            "slug": "h3",
+            "filename": "1_1-1_h3.md",
+        },
     ]
 
 
@@ -21,7 +39,25 @@ def test_strip_numbers(tmp_path):
     md_file.write_text("# 1 Intro\n## 1.1 Segundo\n### 1.1.1 Tercero\n", encoding="utf-8")
     result = build_headings_map(md_folder)
     assert result == [
-        {"level": 1, "title": "1 Intro", "slug": "1-intro"},
-        {"level": 2, "title": "Segundo", "slug": "segundo"},
-        {"level": 3, "title": "Tercero", "slug": "tercero"},
+        {
+            "id": "1",
+            "level": 1,
+            "title": "1 Intro",
+            "slug": "1-intro",
+            "filename": "1_1-intro.md",
+        },
+        {
+            "id": "1.1",
+            "level": 2,
+            "title": "Segundo",
+            "slug": "segundo",
+            "filename": "1_1_segundo.md",
+        },
+        {
+            "id": "1.1.1",
+            "level": 3,
+            "title": "Tercero",
+            "slug": "tercero",
+            "filename": "1_1-1_tercero.md",
+        },
     ]


### PR DESCRIPTION
## Summary
- extend `build_headings_map` to compute `id` and `filename`
- enrich `save_map_yaml` to keep/use these fields
- update `test_headings_map` and `test_cli` expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f54418720833389f13ca9812db808