### PR TITLE
Fix wiki path inconsistencies

### DIFF
--- a/src/wiki/processing/headings_map.py
+++ b/src/wiki/processing/headings_map.py
@@ -44,11 +44,7 @@ def build_headings_map(
 
                     slug = safe_slug(title, used_slugs)
 
-                    parts = identifier.split(".")
-                    doc_id = parts[0]
-                    section_id = "-".join(parts[1:])
-                    prefix = f"{doc_id}_{section_id}" if section_id else doc_id
-                    filename = f"{prefix}_{slug}.md"
+                    filename = f"{slug}.md"
 
                     map_data.append(
                         {
@@ -80,11 +76,7 @@ def save_map_yaml(map_data: List[Dict[str, str | int]], path: Path) -> None:
         slug = str(item.get("slug", ""))
         filename = item.get("filename")
         if not filename and identifier and slug:
-            parts = str(identifier).split(".")
-            doc_id = parts[0]
-            section_id = "-".join(parts[1:])
-            prefix = f"{doc_id}_{section_id}" if section_id else doc_id
-            filename = f"{prefix}_{slug}.md"
+            filename = f"{slug}.md"
 
         enriched.append({"id": identifier, **item, "filename": filename})
 

--- a/src/wiki/processing/ingest.py
+++ b/src/wiki/processing/ingest.py
@@ -132,12 +132,7 @@ def ingest_content(
         text = "".join(content_map.get(slug, []))
         if not text.strip():
             continue
-        identifier = str(entry.get("id", ""))
-        parts = identifier.split(".")
-        doc_id = parts[0]
-        section_id = "-".join(parts[1:])
-        prefix = f"{doc_id}_{section_id}" if section_id else doc_id
-        path = out_dir / f"{prefix}_{slug}.md"
+        path = out_dir / f"{slug}.md"
 
         meta = _read_front_matter(path)
         created = meta.get("created", datetime.utcnow().isoformat())
@@ -154,29 +149,32 @@ def ingest_content(
             if new_src not in sources:
                 sources.append(new_src)
 
-        header_lines = ["---", f"source: {md_path.name}"]
-        if sources:
-            if len(sources) == 1:
-                header_lines.append(f"doc_source: {sources[0]}")
-            else:
-                header_lines.append("doc_source:")
-                for s in sorted(sources):
-                    header_lines.append(f"  - {s}")
-        elif doc_source is not None:
-            header_lines.append(f"doc_source: {Path(doc_source).stem}.docx")
-        header_lines.append(f"created: {created}")
-        header_lines.append("---\n")
-        header = "\n".join(header_lines)
+        if text.lstrip().startswith("---"):
+            final_text = post_process_text(text)
+        else:
+            header_lines = ["---", f"source: {md_path.name}"]
+            if sources:
+                if len(sources) == 1:
+                    header_lines.append(f"doc_source: {sources[0]}")
+                else:
+                    header_lines.append("doc_source:")
+                    for s in sorted(sources):
+                        header_lines.append(f"  - {s}")
+            elif doc_source is not None:
+                header_lines.append(f"doc_source: {Path(doc_source).stem}.docx")
+            header_lines.append(f"created: {created}")
+            header_lines.append("---\n")
+            header = "\n".join(header_lines)
 
-        meta_parts = [f"source: {md_path.name}"]
-        if sources:
-            meta_parts.append("doc: " + ", ".join(sorted(sources)))
-        meta_parts.append(f"created: {created}")
-        meta_line = (
-            f'<div class="fragment-meta">{" | ".join(meta_parts)}</div>\n\n'
-        )
+            meta_parts = [f"source: {md_path.name}"]
+            if sources:
+                meta_parts.append("doc: " + ", ".join(sorted(sources)))
+            meta_parts.append(f"created: {created}")
+            meta_line = (
+                f'<div class="fragment-meta">{" | ".join(meta_parts)}</div>\n\n'
+            )
 
-        final_text = post_process_text(header + meta_line + text)
+            final_text = post_process_text(header + meta_line + text)
         final_text = fix_image_links(final_text)
         final_text = normalize_image_paths(final_text)
         assert "assets/assets/media/" not in final_text, "\u274c Doble ruta assets detectada"
@@ -197,29 +195,33 @@ def ingest_content(
             new_src = f"{Path(doc_source).stem}.docx"
             if new_src not in sources:
                 sources.append(new_src)
-        header_lines = ["---", f"source: {md_path.name}"]
-        if sources:
-            if len(sources) == 1:
-                header_lines.append(f"doc_source: {sources[0]}")
-            else:
-                header_lines.append("doc_source:")
-                for s in sorted(sources):
-                    header_lines.append(f"  - {s}")
-        elif doc_source is not None:
-            header_lines.append(f"doc_source: {Path(doc_source).stem}.docx")
-        header_lines.append(f"created: {created}")
-        header_lines.append("---\n")
-        header = "\n".join(header_lines)
+        unclassified_text = "".join(unclassified)
+        if unclassified_text.lstrip().startswith("---"):
+            final_text = post_process_text(unclassified_text)
+        else:
+            header_lines = ["---", f"source: {md_path.name}"]
+            if sources:
+                if len(sources) == 1:
+                    header_lines.append(f"doc_source: {sources[0]}")
+                else:
+                    header_lines.append("doc_source:")
+                    for s in sorted(sources):
+                        header_lines.append(f"  - {s}")
+            elif doc_source is not None:
+                header_lines.append(f"doc_source: {Path(doc_source).stem}.docx")
+            header_lines.append(f"created: {created}")
+            header_lines.append("---\n")
+            header = "\n".join(header_lines)
 
-        meta_parts = [f"source: {md_path.name}"]
-        if sources:
-            meta_parts.append("doc: " + ", ".join(sorted(sources)))
-        meta_parts.append(f"created: {created}")
-        meta_line = (
-            f'<div class="fragment-meta">{" | ".join(meta_parts)}</div>\n\n'
-        )
+            meta_parts = [f"source: {md_path.name}"]
+            if sources:
+                meta_parts.append("doc: " + ", ".join(sorted(sources)))
+            meta_parts.append(f"created: {created}")
+            meta_line = (
+                f'<div class="fragment-meta">{" | ".join(meta_parts)}</div>\n\n'
+            )
 
-        final_text = post_process_text(header + meta_line + "".join(unclassified))
+            final_text = post_process_text(header + meta_line + unclassified_text)
         final_text = fix_image_links(final_text)
         final_text = normalize_image_paths(final_text)
         assert "assets/assets/media/" not in final_text, "\u274c Doble ruta assets detectada"

--- a/src/wiki/processing/md_post.py
+++ b/src/wiki/processing/md_post.py
@@ -4,7 +4,9 @@ import re
 from typing import List
 from pathlib import Path
 
-IMAGE_PREFIX_RE = re.compile(r"(!\[[^\]]*\]\()\.?/??(?:assets/)?media/")
+IMAGE_PREFIX_RE = re.compile(
+    r"(!\[[^\]]*\]\()(?:\./|\.\./)*\.?/??(?:assets/)?media/"
+)
 
 
 def fix_image_links(text: str) -> str:

--- a/src/wiki/processing/reclassify.py
+++ b/src/wiki/processing/reclassify.py
@@ -48,12 +48,7 @@ def reclassify_unclassified(
                 best_ratio = ratio
                 best_entry = entry
         if best_entry and best_ratio >= threshold and best_entry.get("slug"):
-            identifier = str(best_entry.get("id", ""))
-            parts = identifier.split(".")
-            doc_id = parts[0]
-            section_id = "-".join(parts[1:])
-            prefix = f"{doc_id}_{section_id}" if section_id else doc_id
-            md_file = wiki_dir / f"{prefix}_{best_entry['slug']}.md"
+            md_file = wiki_dir / f"{best_entry['slug']}.md"
             md_file.parent.mkdir(parents=True, exist_ok=True)
             with md_file.open("a", encoding="utf-8") as f:
                 if lines and not lines[-1].endswith("\n"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,7 +90,7 @@ def test_map_command(tmp_path, monkeypatch):
     data = yaml.safe_load(map_file.read_text(encoding="utf-8"))
     assert data[0]["slug"] == "title"
     assert data[0]["id"] == "1"
-    assert data[0]["filename"] == "1_title.md"
+    assert data[0]["filename"] == "title.md"
 
 
 def test_index_overwrite(tmp_path, monkeypatch):
@@ -113,7 +113,7 @@ def test_index_overwrite(tmp_path, monkeypatch):
 
 def test_sidebar_command(tmp_path, monkeypatch):
     map_data = [
-        {"level": 1, "title": "A", "filename": "1_a.md"},
+        {"level": 1, "title": "A", "filename": "a.md"},
     ]
     work = tmp_path
     (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
@@ -125,12 +125,12 @@ def test_sidebar_command(tmp_path, monkeypatch):
     sidebar = work / "_sidebar.md"
     assert sidebar.exists()
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content == ["* [A](1_a.md)"]
+    assert content == ["* [A](a.md)"]
 
 
 def test_sidebar_command_absolute(tmp_path, monkeypatch):
     map_data = [
-        {"level": 1, "title": "A", "filename": "1_a.md"},
+        {"level": 1, "title": "A", "filename": "a.md"},
     ]
     work = tmp_path
     (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
@@ -141,13 +141,13 @@ def test_sidebar_command_absolute(tmp_path, monkeypatch):
     assert result.exit_code == 0
     sidebar = work / "_sidebar.md"
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content == ["* [A](/wiki/1_a.md)"]
+    assert content == ["* [A](/wiki/a.md)"]
 
 
 def test_search_index_command(tmp_path, monkeypatch):
     wiki_dir = tmp_path / "wiki"
     wiki_dir.mkdir()
-    (wiki_dir / "1_a.md").write_text("# Title\nBody", encoding="utf-8")
+    (wiki_dir / "a.md").write_text("# Title\nBody", encoding="utf-8")
     monkeypatch.setattr("wiki.cli.cfg", {"paths": {"wiki": wiki_dir}})
 
     result = runner.invoke(app, ["search-index"])

--- a/tests/test_headings_map.py
+++ b/tests/test_headings_map.py
@@ -13,21 +13,21 @@ def test_build_headings_map(tmp_path):
             "level": 1,
             "title": "H1",
             "slug": "h1",
-            "filename": "1_h1.md",
+            "filename": "h1.md",
         },
         {
             "id": "1.1",
             "level": 2,
             "title": "H2",
             "slug": "h2",
-            "filename": "1_1_h2.md",
+            "filename": "h2.md",
         },
         {
             "id": "1.1.1",
             "level": 3,
             "title": "H3",
             "slug": "h3",
-            "filename": "1_1-1_h3.md",
+            "filename": "h3.md",
         },
     ]
 
@@ -44,20 +44,20 @@ def test_strip_numbers(tmp_path):
             "level": 1,
             "title": "1 Intro",
             "slug": "1-intro",
-            "filename": "1_1-intro.md",
+            "filename": "1-intro.md",
         },
         {
             "id": "1.1",
             "level": 2,
             "title": "Segundo",
             "slug": "segundo",
-            "filename": "1_1_segundo.md",
+            "filename": "segundo.md",
         },
         {
             "id": "1.1.1",
             "level": 3,
             "title": "Tercero",
             "slug": "tercero",
-            "filename": "1_1-1_tercero.md",
+            "filename": "tercero.md",
         },
     ]

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -18,8 +18,8 @@ def test_ingest_content(tmp_path):
     out_dir = tmp_path / "wiki"
     ingest_content(md, index_path, out_dir, cutoff=0.5, doc_source="estado_actual")
 
-    first = out_dir / "1_x.md"
-    second = out_dir / "2_z.md"
+    first = out_dir / "x.md"
+    second = out_dir / "z.md"
     assert first.exists()
     assert second.exists()
     assert not (out_dir / "99_unclassified.md").exists()

--- a/tests/test_ingest_sources.py
+++ b/tests/test_ingest_sources.py
@@ -18,7 +18,7 @@ def test_ingest_multiple_sources(tmp_path):
     ingest_content(md_a, index_path, out_dir, cutoff=0.5, doc_source="DocA")
     ingest_content(md_b, index_path, out_dir, cutoff=0.5, doc_source="DocB")
 
-    final = out_dir / "1_introduccion.md"
+    final = out_dir / "introduccion.md"
     assert final.exists()
     content = final.read_text(encoding="utf-8")
     lines = content.splitlines()

--- a/tests/test_md_post.py
+++ b/tests/test_md_post.py
@@ -41,8 +41,8 @@ def test_fix_image_links_and_warning(tmp_path, capsys):
     warn_missing_images(fixed, tmp_path)
     captured = capsys.readouterr()
     assert 'assets/media/img.png' in fixed
-    assert '../media/img2.jpg' in fixed
-    assert 'img2.jpg' not in captured.out
+    assert 'assets/media/img2.jpg' in fixed
+    assert 'img2.jpg' in captured.out
 
 
 def test_fix_image_links_no_duplicate():

--- a/tests/test_pipeline_doc_sources.py
+++ b/tests/test_pipeline_doc_sources.py
@@ -58,7 +58,7 @@ def test_full_multiple_doc_sources(tmp_path, monkeypatch):
     result = runner.invoke(app, ["full"])
     assert result.exit_code == 0
 
-    final = paths["wiki"] / "1_introduccion.md"
+    final = paths["wiki"] / "introduccion.md"
     assert final.exists()
     lines = final.read_text(encoding="utf-8").splitlines()
     assert lines[0] == "---"

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -19,9 +19,9 @@ def _setup(tmp_path):
         {"id": "2", "title": "Second", "slug": "second", "children": []},
     ]
     (work / "index.yaml").write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
-    first = wiki / "1_first.md"
+    first = wiki / "first.md"
     first.write_text("---\n---\n# First\nold\n", encoding="utf-8")
-    second = wiki / "2_second.md"
+    second = wiki / "second.md"
     second.write_text("---\n---\n# Second\n", encoding="utf-8")
     unclassified = wiki / "99_unclassified.md"
     unclassified.write_text("---\n---\n# First\nadd1\n# Unknown\nadd2\n", encoding="utf-8")
@@ -31,7 +31,7 @@ def _setup(tmp_path):
 def test_reclassify_unclassified(tmp_path):
     work, wiki, unclassified = _setup(tmp_path)
     reclassify_unclassified(unclassified, work / "index.yaml", wiki, threshold=0.3)
-    content = (wiki / "1_first.md").read_text(encoding="utf-8")
+    content = (wiki / "first.md").read_text(encoding="utf-8")
     assert "add1" in content
     report = wiki / "report_reclassify.csv"
     assert report.exists()
@@ -44,5 +44,5 @@ def test_reclassify_cli(tmp_path, monkeypatch):
     monkeypatch.setattr("wiki.cli.cfg", {"paths": {"work": work, "wiki": wiki}})
     result = runner.invoke(app, ["reclassify", "--threshold", "0.3"])
     assert result.exit_code == 0
-    assert "add1" in (wiki / "1_first.md").read_text(encoding="utf-8")
+    assert "add1" in (wiki / "first.md").read_text(encoding="utf-8")
 

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -8,10 +8,10 @@ def test_sidebar_generation(tmp_path):
         """
 - level: 1
   title: Introducción
-  filename: 1_1-introduccion.md
+  filename: introduccion.md
 - level: 2
   title: Alcance
-  filename: 1_2-alcance.md
+  filename: alcance.md
 """,
         encoding="utf-8",
     )
@@ -21,5 +21,5 @@ def test_sidebar_generation(tmp_path):
     build_sidebar(map_file, wiki_dir, absolute_links=False)
 
     sidebar_content = (wiki_dir / "_sidebar.md").read_text(encoding="utf-8")
-    assert "* [Introducción](1_1-introduccion.md)" in sidebar_content
-    assert "  * [Alcance](1_2-alcance.md)" in sidebar_content
+    assert "* [Introducción](introduccion.md)" in sidebar_content
+    assert "  * [Alcance](alcance.md)" in sidebar_content

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -13,7 +13,7 @@
       window.$docsify = {
         name: 'Wiki Documental',
         loadSidebar: true,
-        subMaxLevel: 3,
+        subMaxLevel: 4,
         search: 'auto'
       }
     </script>


### PR DESCRIPTION
## Summary
- save wiki fragments using only their slug
- normalize image links with `../` prefixes
- skip front-matter injection when text already contains YAML
- update map generation and reclassification for new slug names
- expand Docsify sidebar depth
- adjust unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5b4215b08333aa2b1e94ac75f355