### PR TITLE
Improve image path normalization

### DIFF
--- a/src/wiki/processing/md_post.py
+++ b/src/wiki/processing/md_post.py
@@ -7,11 +7,15 @@ from pathlib import Path
 IMAGE_PREFIX_RE = re.compile(
     r"(!\[[^\]]*\]\()(?:\./|\.\./)*\.?/??(?:assets/)?media/"
 )
+IMG_TAG_PREFIX_RE = re.compile(
+    r"(<img[^>]*src=\")(?:\./|\.\./)*\.?/??(?:assets/)?media/"
+)
 
 
 def fix_image_links(text: str) -> str:
     """Normalize media links ensuring the assets prefix."""
     text = IMAGE_PREFIX_RE.sub(r"\1assets/media/", text)
+    text = IMG_TAG_PREFIX_RE.sub(r"\1assets/media/", text)
     text = re.sub(r"(assets/)+media/", "assets/media/", text)
     text = re.sub(r"(media/)+", "media/", text)
     return text
@@ -27,6 +31,12 @@ def normalize_image_paths(md_text: str) -> str:
         return f"(assets/media/{name})"
 
     md_text = re.sub(r"\(([a-zA-Z]:[^)]+)\)", repl, md_text)
+    def repl_img(match: re.Match[str]) -> str:
+        path = match.group(1)
+        name = Path(path).name.replace("\\", "/")
+        return f'src="assets/media/{name}"'
+
+    md_text = re.sub(r'src="([a-zA-Z]:[^"]+)"', repl_img, md_text)
     return md_text
 
 

--- a/tests/test_md_post.py
+++ b/tests/test_md_post.py
@@ -56,3 +56,16 @@ def test_normalize_image_paths():
     assert '\\' not in result
     assert 'C:/' not in result
     assert 'assets/media/img.png' in result
+
+
+def test_fix_image_links_html_img():
+    text = '<img src="../media/img.png">'
+    fixed = fix_image_links(text)
+    assert fixed == '<img src="assets/media/img.png">'
+
+
+def test_normalize_image_paths_html():
+    text = '<img src="C:/temp/foo.png">'
+    result = normalize_image_paths(text)
+    assert 'C:/' not in result
+    assert result == '<img src="assets/media/foo.png">'


### PR DESCRIPTION
## Summary
- handle `<img>` tags and Windows paths in image sanitizer
- cover new cases in md_post tests

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6affae608333afb5cb197356b40a