### PR TITLE
Fix slug generation for level 1 headings

### DIFF
--- a/src/wiki/processing/headings_map.py
+++ b/src/wiki/processing/headings_map.py
@@ -19,7 +19,7 @@ def build_headings_map(
     md_folder: Path,
     *,
     strip_numbers: bool = True,
-    from_level: int = 2,
+    from_level: int = 1,
 ) -> List[Dict[str, str | int]]:
     """Return a list of heading data dictionaries."""
     map_data: List[Dict[str, str | int]] = []


### PR DESCRIPTION
## Summary
- strip numbering from level 1 titles when generating heading slugs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6cfda3248333b6b237424d826ecf