### PR TITLE
Improve heading cleanup and docsify scrolling

### DIFF
--- a/src/wiki/processing/md_post.py
+++ b/src/wiki/processing/md_post.py
@@ -50,8 +50,11 @@ def warn_missing_images(text: str, wiki_dir: Path) -> None:
             print(f"Warning: missing image {wiki_dir / rel}")
 
 
-_HEADING2_RE = re.compile(r"^##\s")
-_HEADING3_RE = re.compile(r"^###\s")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_NUMBER_RE = re.compile(r"^\d+(?:\.\d+)*\s+")
+_TAG_RE = re.compile(r"<[^>]+>")
+_SUB_TAG_RE = re.compile(r"<sub>.*?</sub>", flags=re.I)
+_SUP_TAG_RE = re.compile(r"<sup>.*?</sup>", flags=re.I)
 
 
 def clean_lines(lines: List[str]) -> List[str]:
@@ -62,18 +65,27 @@ def clean_lines(lines: List[str]) -> List[str]:
         if len(stripped) > 120 and set(stripped) == {"."}:
             # drop long leader dot lines
             continue
-        if _HEADING2_RE.match(stripped) or _HEADING3_RE.match(stripped):
-            # ensure blank line before secondary headings
-            if cleaned and cleaned[-1].strip() != "":
+
+        m = _HEADING_RE.match(stripped)
+        if m:
+            level = len(m.group(1))
+            prefix = m.group(1)
+            title = m.group(2)
+            if level > 1 and cleaned and cleaned[-1].strip() != "":
+                # ensure blank line before secondary headings
                 cleaned.append("\n")
-            # normalize heading text
-            parts = stripped.split(maxsplit=1)
-            prefix = parts[0]
-            title = parts[1] if len(parts) > 1 else ""
+
             title = title.replace("**", " ")
+            title = _SUB_TAG_RE.sub("", title)
+            title = _SUP_TAG_RE.sub("", title)
+            title = _TAG_RE.sub("", title)
+            title = _NUMBER_RE.sub("", title)
             title = re.sub(r"\s+", " ", title).strip()
+
             line = f"{prefix} {title}\n"
+
         cleaned.append(line)
+
     return cleaned
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -35,3 +35,23 @@ def test_ingest_content(tmp_path):
     assert "## Y" in content
     assert "### Zeta" in content
 
+
+def test_ingest_heading_clean(tmp_path):
+    md = tmp_path / "full.md"
+    md.write_text("# 1 Introducción <sub>a</sub>\nTexto\n", encoding="utf-8")
+
+    index = [{"id": "1", "title": "Introducción", "slug": "introduccion", "children": []}]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+
+    out_dir = tmp_path / "wiki"
+    ingest_content(md, index_path, out_dir, cutoff=0.5, doc_source="DocA")
+
+    final = out_dir / "introduccion.md"
+    assert final.exists()
+    lines = final.read_text(encoding="utf-8").splitlines()
+    end = lines.index("---", 1)
+    body = lines[end + 1:]
+    heading = next(l for l in body if l.startswith('#'))
+    assert heading == '# Introducción'
+

--- a/tests/test_md_post.py
+++ b/tests/test_md_post.py
@@ -31,6 +31,13 @@ def test_heading_cleanup():
     assert lines[2] == '### Another Title'
 
 
+def test_heading_cleanup_h1():
+    text = '# 1 Introducción <sub>draft</sub>\ncontenido\n'
+    result = clean_markdown(text)
+    lines = result.splitlines()
+    assert lines[0] == '# Introducción'
+
+
 def test_fix_image_links_and_warning(tmp_path, capsys):
     text = '![a](media/img.png) and ![](../media/img2.jpg)'
     assets = tmp_path / 'assets' / 'media'

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -19,5 +19,14 @@
     </script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
     <script src="plugins/search.min.js"></script>
+    <script>
+      if (window.$docsify) {
+        window.$docsify.plugins = [].concat(function (hook) {
+          hook.doneEach(function () {
+            window.scrollTo(0, 0);
+          });
+        }, window.$docsify.plugins || []);
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- clean all heading levels to remove numbers and sub/sup tags
- reset scroll position with a Docsify plugin
- test heading cleanup on H1
- test ingest output heading normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6e84ebfc8333a37852c897da185f