### PR TITLE
Fix sidebar generation using index slugs

### DIFF
--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -16,7 +16,7 @@ Se actualiza tras cada cambio relevante mediante tareas formales.
 | `md_post.py` | Limpia puntos y corrige saltos | ✅ (post-ingestión) | N/A |
 | `normalize_docx.py` | Aplica estilos estructurados | ✅ | ❌ |
 | `reclassify.py` | Redistribuye contenido `unclassified` | ❌ (manual) | ✅ |
-| `sidebar.py` | Genera `_sidebar.md` | ✅ | ✅ |
+| `sidebar.py` | Genera `_sidebar.md` desde `index.yaml` | ✅ | ✅ |
 | `style_map.py` | Reglas de estilo de headings | ✅ (desde `normalize_docx`) | ❌ |
 | `verify_pre_ingest.py` | Verifica coherencia `map` ↔ `index` | ✅ | ❌ |
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -173,7 +173,7 @@ def full(
     console.print("[bold]Generating sidebar...[/bold]")
     abs_links = ctx.obj.get("absolute_links", False) if ctx.obj else False
     build_sidebar(
-        map_path=map_path,
+        index_path=index_path,
         wiki_dir=wiki_dir,
         absolute_links=abs_links,
     )
@@ -320,10 +320,10 @@ def ingest(file: Path) -> None:
 @app.command()
 def sidebar(ctx: typer.Context) -> None:
     """Generate _sidebar.md for Docsify."""
-    map_path = cfg["paths"]["work"] / "map.yaml"
+    index_path = cfg["paths"]["work"] / "index.yaml"
     wiki_dir = cfg["paths"]["wiki"]
     abs_links = ctx.obj.get("absolute_links", False) if ctx.obj else False
-    build_sidebar(map_path, wiki_dir, absolute_links=abs_links)
+    build_sidebar(index_path, wiki_dir, absolute_links=abs_links)
     typer.echo("Sidebar generated")
 
 

--- a/src/wiki/processing/sidebar.py
+++ b/src/wiki/processing/sidebar.py
@@ -2,21 +2,27 @@ import yaml
 from pathlib import Path
 
 
-def build_sidebar(map_path: Path, wiki_dir: Path, absolute_links: bool = False) -> None:
-    """Generate a Docsify sidebar from map.yaml."""
-    with map_path.open(encoding="utf-8") as f:
-        headings = yaml.safe_load(f) or []
-
-    lines = []
-    for item in headings:
-        level = int(item.get("level", 1))
-        title = item.get("title", "")
-        filename = item.get("filename")
-        if not filename:
+def _traverse_index(entries: list[dict], lines: list[str], level: int, absolute: bool) -> None:
+    for entry in entries:
+        title = entry.get("title", "")
+        slug = entry.get("slug")
+        if not slug:
             continue
-        link = f"/wiki/{filename}" if absolute_links else filename
+        filename = f"{slug}.md"
+        link = f"/wiki/{filename}" if absolute else filename
         indent = "  " * (level - 1)
         lines.append(f"{indent}* [{title}]({link})")
+        children = entry.get("children") or []
+        _traverse_index(children, lines, level + 1, absolute)
+
+
+def build_sidebar(index_path: Path, wiki_dir: Path, absolute_links: bool = False) -> None:
+    """Generate a Docsify sidebar from index.yaml."""
+    with index_path.open(encoding="utf-8") as f:
+        index_data = yaml.safe_load(f) or []
+
+    lines: list[str] = []
+    _traverse_index(index_data, lines, 1, absolute_links)
 
     sidebar_path = wiki_dir / "_sidebar.md"
     sidebar_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,11 +112,11 @@ def test_index_overwrite(tmp_path, monkeypatch):
 
 
 def test_sidebar_command(tmp_path, monkeypatch):
-    map_data = [
-        {"level": 1, "title": "A", "filename": "a.md"},
+    index_data = [
+        {"id": "1", "title": "A", "slug": "a", "children": []},
     ]
     work = tmp_path
-    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
 
@@ -129,11 +129,11 @@ def test_sidebar_command(tmp_path, monkeypatch):
 
 
 def test_sidebar_command_absolute(tmp_path, monkeypatch):
-    map_data = [
-        {"level": 1, "title": "A", "filename": "a.md"},
+    index_data = [
+        {"id": "1", "title": "A", "slug": "a", "children": []},
     ]
     work = tmp_path
-    (work / "map.yaml").write_text(yaml.safe_dump(map_data, allow_unicode=True), encoding="utf-8")
+    (work / "index.yaml").write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
     paths = {"work": work, "wiki": work}
     monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
 

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -1,24 +1,25 @@
 from wiki.processing.sidebar import build_sidebar
-from pathlib import Path
 
 
 def test_sidebar_generation(tmp_path):
-    map_file = tmp_path / "map.yaml"
-    map_file.write_text(
+    index_file = tmp_path / "index.yaml"
+    index_file.write_text(
         """
-- level: 1
+- id: '1'
   title: Introducción
-  filename: introduccion.md
-- level: 2
-  title: Alcance
-  filename: alcance.md
+  slug: introduccion
+  children:
+    - id: '1.1'
+      title: Alcance
+      slug: alcance
+      children: []
 """,
         encoding="utf-8",
     )
 
     wiki_dir = tmp_path / "wiki"
     wiki_dir.mkdir()
-    build_sidebar(map_file, wiki_dir, absolute_links=False)
+    build_sidebar(index_file, wiki_dir, absolute_links=False)
 
     sidebar_content = (wiki_dir / "_sidebar.md").read_text(encoding="utf-8")
     assert "* [Introducción](introduccion.md)" in sidebar_content


### PR DESCRIPTION
## Summary
- build sidebar from `index.yaml` instead of `map.yaml`
- update CLI commands accordingly
- clarify documentation on sidebar generation
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7521bae0833388af2a7dddaa50c1