### PR TITLE
Improve sidebar generation filtering

### DIFF
--- a/src/wiki/processing/sidebar.py
+++ b/src/wiki/processing/sidebar.py
@@ -1,28 +1,90 @@
+import re
 import yaml
 from pathlib import Path
 
 
-def _traverse_index(entries: list[dict], lines: list[str], level: int, absolute: bool) -> None:
+_HEADING_RE = re.compile(r"^#{1,6}\s+.+")
+
+
+def _has_valid_title(path: Path) -> bool:
+    """Return ``True`` if ``path`` contains a Markdown heading."""
+    if not path.exists():
+        return True
+    lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    i = 0
+    if lines and lines[0].strip() == "---":
+        for j in range(1, len(lines)):
+            if lines[j].strip() == "---":
+                i = j + 1
+                break
+    for line in lines[i:]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        return bool(_HEADING_RE.match(stripped))
+    return False
+
+
+def _traverse_index(
+    entries: list[dict],
+    lines: list[str],
+    wiki_dir: Path,
+    level: int,
+    absolute: bool,
+    *,
+    exclude_prefix: str | None,
+    max_slug_len: int | None,
+) -> None:
     for entry in entries:
         title = entry.get("title", "")
         slug = entry.get("slug")
         if not slug:
             continue
+        if exclude_prefix and slug.startswith(exclude_prefix):
+            continue
+        if max_slug_len and len(slug) > max_slug_len:
+            continue
         filename = f"{slug}.md"
+        path = wiki_dir / filename
+        if not _has_valid_title(path):
+            continue
         link = f"/wiki/{filename}" if absolute else filename
         indent = "  " * (level - 1)
         lines.append(f"{indent}* [{title}]({link})")
         children = entry.get("children") or []
-        _traverse_index(children, lines, level + 1, absolute)
+        _traverse_index(
+            children,
+            lines,
+            wiki_dir,
+            level + 1,
+            absolute,
+            exclude_prefix=exclude_prefix,
+            max_slug_len=max_slug_len,
+        )
 
 
-def build_sidebar(index_path: Path, wiki_dir: Path, absolute_links: bool = False) -> None:
-    """Generate a Docsify sidebar from index.yaml."""
+def build_sidebar(
+    index_path: Path,
+    wiki_dir: Path,
+    absolute_links: bool = False,
+    *,
+    exclude_prefix: str | None = "fragmento_",
+    max_slug_len: int | None = 120,
+) -> None:
+    """Generate a Docsify sidebar from index.yaml applying simple filters."""
     with index_path.open(encoding="utf-8") as f:
         index_data = yaml.safe_load(f) or []
 
     lines: list[str] = []
-    _traverse_index(index_data, lines, 1, absolute_links)
+    _traverse_index(
+        index_data,
+        lines,
+        wiki_dir,
+        1,
+        absolute_links,
+        exclude_prefix=exclude_prefix,
+        max_slug_len=max_slug_len,
+    )
 
     sidebar_path = wiki_dir / "_sidebar.md"
     sidebar_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_sidebar_filter.py
+++ b/tests/test_sidebar_filter.py
@@ -1,0 +1,31 @@
+import yaml
+from wiki.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_sidebar_filters(tmp_path, monkeypatch):
+    index_data = [
+        {"id": "1", "title": "A", "slug": "a", "children": []},
+        {"id": "2", "title": "B", "slug": "fragmento_b", "children": []},
+        {"id": "3", "title": "C", "slug": "c", "children": []},
+        {"id": "4", "title": "D", "slug": "d" * 121, "children": []},
+    ]
+    (tmp_path / "index.yaml").write_text(
+        yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8"
+    )
+    paths = {"work": tmp_path, "wiki": tmp_path}
+    monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
+
+    (tmp_path / "a.md").write_text("# Title\n", encoding="utf-8")
+    (tmp_path / "fragmento_b.md").write_text("# Title\n", encoding="utf-8")
+    (tmp_path / "c.md").write_text("Sin encabezado\n", encoding="utf-8")
+    (tmp_path / ("d" * 121 + ".md")).write_text("# Largo\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["sidebar"])
+    assert result.exit_code == 0
+    sidebar = tmp_path / "_sidebar.md"
+    assert sidebar.exists()
+    content = sidebar.read_text(encoding="utf-8").splitlines()
+    assert content == ["* [A](a.md)"]


### PR DESCRIPTION
## Summary
- update `sidebar` processing to ignore bad fragments
- provide exclude_prefix and max_slug_len options
- add regression tests for sidebar filtering

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e234c2cc833391714a1b8b2ac9e1