### PR TITLE
Fix fragment meta duplication on re-ingest

### DIFF
--- a/src/wiki/processing/ingest.py
+++ b/src/wiki/processing/ingest.py
@@ -202,7 +202,11 @@ def ingest_content(
             f'<div class="fragment-meta">{" | ".join(meta_parts)}</div>\n\n'
         )
 
-        final_text = post_process_text(header + meta_line + body)
+        body_lines = body.splitlines()
+        if not any("fragment-meta" in line for line in body_lines[:5]):
+            body = meta_line + body
+
+        final_text = post_process_text(header + body)
         final_text = fix_image_links(final_text)
         final_text = normalize_image_paths(final_text)
         assert "assets/assets/media/" not in final_text, "\u274c Doble ruta assets detectada"
@@ -247,7 +251,11 @@ def ingest_content(
             f'<div class="fragment-meta">{" | ".join(meta_parts)}</div>\n\n'
         )
 
-        final_text = post_process_text(header + meta_line + body)
+        body_lines = body.splitlines()
+        if not any("fragment-meta" in line for line in body_lines[:5]):
+            body = meta_line + body
+
+        final_text = post_process_text(header + body)
         final_text = fix_image_links(final_text)
         final_text = normalize_image_paths(final_text)
         assert "assets/assets/media/" not in final_text, "\u274c Doble ruta assets detectada"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -55,3 +55,26 @@ def test_ingest_heading_clean(tmp_path):
     heading = next(l for l in body if l.startswith('#'))
     assert heading == '# Introducción'
 
+
+def test_ingest_no_duplicate_meta(tmp_path):
+    md = tmp_path / "full.md"
+    md.write_text(
+        "---\nsource: full.md\n---\n"
+        "<div class=\"fragment-meta\">source: full.md | doc: DocA.docx | created: 2020-01-01</div>\n\n"
+        "# Seccion\nTexto\n",
+        encoding="utf-8",
+    )
+
+    index = [{"id": "1", "title": "Seccion", "slug": "seccion", "children": []}]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+
+    out_dir = tmp_path / "wiki"
+    ingest_content(md, index_path, out_dir, cutoff=0.5, doc_source="DocA")
+
+    final = out_dir / "seccion.md"
+    assert final.exists()
+    lines = final.read_text(encoding="utf-8").splitlines()
+    meta_lines = [l for l in lines if '<div class="fragment-meta">' in l]
+    assert len(meta_lines) == 1
+


### PR DESCRIPTION
## Summary
- avoid writing another fragment metadata block if one is already present near the top of the fragment
- test that ingesting a markdown file with an existing metadata block keeps only one block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851eacfe76483338372df49f4d6ce51