### PR TITLE
Update preprocess paths

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,7 @@
 paths:
-  originals: "inputs/_originals"
+  originals: "work/to_process"
+  cleaned_input: "inputs/_originals"
+  cleaned_output: "work/cleaned"
   work: "work"
   wiki: "wiki"
   tmp: "work/tmp"

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -375,10 +375,29 @@ def preprocess_docs_batch() -> None:
     """Limpia y convierte documentos .docx y .pdf en formato procesable."""
     from .tools.preprocess_documents import batch_process_directory
 
-    input_dir = Path(cfg["paths"]["originals"])
-    output_dir = Path(cfg["paths"]["work"]) / "cleaned"
+    input_dir = Path(cfg["paths"]["cleaned_input"])
+    output_dir = Path(cfg["paths"]["cleaned_output"])
     output_dir.mkdir(parents=True, exist_ok=True)
 
     batch_process_directory(input_dir, output_dir)
     typer.echo(f"\u2705 Documentos limpios generados en: {output_dir}")
+
+
+@app.command("prepare-to-process")
+def move_cleaned_to_process() -> None:
+    """Copia archivos limpios desde cleaned → to_process (para ejecución de wiki full)."""
+    from shutil import copyfile
+    from pathlib import Path
+    from yaml import safe_load
+
+    cfg_path = Path("config.yaml")
+    cfg = safe_load(cfg_path.read_text(encoding="utf-8"))
+
+    cleaned_dir = Path(cfg["paths"]["cleaned_output"])
+    process_dir = Path(cfg["paths"]["originals"])
+    process_dir.mkdir(parents=True, exist_ok=True)
+
+    for f in cleaned_dir.glob("*.docx"):
+        copyfile(f, process_dir / f.name)
+        print(f"\u2713 {f.name} → {process_dir}")
 

--- a/src/wiki/tools/preprocess_documents.py
+++ b/src/wiki/tools/preprocess_documents.py
@@ -3,6 +3,7 @@ import docx
 from docx.document import Document
 from docx.text.paragraph import Paragraph
 from pdf2docx import Converter
+from yaml import safe_load
 
 # --- Heurísticas de detección de encabezados ---
 HEADING_1_MIN_FONT_SIZE = 14  # pt
@@ -72,3 +73,13 @@ def batch_process_directory(input_dir: Path, output_dir: Path):
                 print(f"\u274c Error al convertir {file.name}: {e}")
 
     print("\n\u2705 Limpieza completada.")
+
+
+if __name__ == "__main__":
+    cfg_path = Path("config.yaml")
+    cfg = safe_load(cfg_path.read_text(encoding="utf-8"))
+
+    input_dir = Path(cfg["paths"]["cleaned_input"])
+    output_dir = Path(cfg["paths"]["cleaned_output"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    batch_process_directory(input_dir, output_dir)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,9 @@ def test_load_config_creates_directories(tmp_path, monkeypatch):
     (root / "src/wiki").mkdir(parents=True)
     config_yaml = (
         "paths:\n"
-        "  originals: 'inputs/_originals'\n"
+        "  originals: 'work/to_process'\n"
+        "  cleaned_input: 'inputs/_originals'\n"
+        "  cleaned_output: 'work/cleaned'\n"
         "  work: 'work'\n"
         "  wiki: 'wiki'\n"
         "  tmp: 'work/tmp'\n"

--- a/tests/test_preprocess_documents.py
+++ b/tests/test_preprocess_documents.py
@@ -44,7 +44,12 @@ def test_cli_preprocess_docs(tmp_path, monkeypatch):
             pass
 
     monkeypatch.setattr("wiki.tools.preprocess_documents.Converter", DummyConverter)
-    monkeypatch.setattr("wiki.cli.cfg", {"paths": {"originals": orig, "work": work}})
+    paths = {
+        "cleaned_input": orig,
+        "cleaned_output": work / "cleaned",
+        "originals": work / "to_process",
+    }
+    monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
 
     result = runner.invoke(app, ["preprocess-docs"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- route preprocess-docs to use new cleaned_input & cleaned_output paths
- add prepare-to-process command for copying cleaned docs
- update preprocess script to load config paths when run standalone
- adjust config defaults for separated directories
- keep tests in sync with new configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b56dc5f88333acdc9201d1af463d