### PR TITLE
Enhance preprocess-docs with auto-copy

### DIFF
--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -371,7 +371,11 @@ def clean_docx_batch() -> None:
 
 
 @app.command("preprocess-docs")
-def preprocess_docs_batch() -> None:
+def preprocess_docs_batch(
+    overwrite: bool = typer.Option(
+        False, "--overwrite", help="Sobrescribir archivos existentes en to_process"
+    )
+) -> None:
     """Limpia y convierte documentos .docx y .pdf en formato procesable."""
     from .tools.preprocess_documents import batch_process_directory
 
@@ -381,6 +385,23 @@ def preprocess_docs_batch() -> None:
 
     batch_process_directory(input_dir, output_dir)
     typer.echo(f"\u2705 Documentos limpios generados en: {output_dir}")
+
+    # Copia automática de documentos limpios al directorio de entrada para wiki full
+    to_process_dir = Path(cfg["paths"]["originals"])
+    cleaned_dir = Path(cfg["paths"]["cleaned_output"])
+
+    to_process_dir.mkdir(parents=True, exist_ok=True)
+    copied_files = 0
+
+    for docx_file in cleaned_dir.glob("*.docx"):
+        dest = to_process_dir / docx_file.name
+        if overwrite or not dest.exists():
+            shutil.copy(docx_file, dest)
+            copied_files += 1
+
+    print(
+        f"\U0001f4e4 {copied_files} archivos copiados a {to_process_dir} para procesamiento posterior."
+    )
 
 
 @app.command("prepare-to-process")

--- a/tests/test_preprocess_documents.py
+++ b/tests/test_preprocess_documents.py
@@ -63,3 +63,9 @@ def test_cli_preprocess_docs(tmp_path, monkeypatch):
     assert pdf_cleaned.exists()
     pdf_doc = Document(pdf_cleaned)
     assert pdf_doc.paragraphs[0].style.name == "Heading 1"
+
+    # Cleaned files should be automatically copied for processing
+    doc_copied = work / "to_process" / "sample.docx"
+    pdf_copied = work / "to_process" / "sample_pdf.docx"
+    assert doc_copied.exists()
+    assert pdf_copied.exists()


### PR DESCRIPTION
## Summary
- copy cleaned docs to `to_process` after running `preprocess-docs`
- add `--overwrite` option for forcing overwrite
- test that cleaned documents are copied automatically

## Testing
- `pytest tests/test_preprocess_documents.py::test_cli_preprocess_docs -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ba48781883338133eaed566b308e