### PR TITLE
Add work/inputs ignore and clean docx on reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ work/media/
 work/tmp/
 work/*.yaml
 work/*.csv
+work/
+inputs/
 
 # Reclasificaciones y backups
 wiki/99_unclassified.*

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Generate `index.yaml` from the headings map. Options:
 Run the entire conversion pipeline from DOCX originals to the final wiki.
 
 ### `wiki reset`
-Remove generated Markdown, YAML and CSV files from `work` and `wiki`.
+Remove generated Markdown, YAML and CSV files from `work` and `wiki`. Any DOCX
+files found inside `work` are also deleted.
 
 ### `wiki normalize`
 Normalize a DOCX file so paragraph styles become proper heading levels.

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -30,6 +30,11 @@ def reset_environment(cfg: dict) -> None:
                     continue
                 f.unlink()
                 console.log(f"Deleted {f}")
+
+    # Remove any DOCX files left in the work directory
+    for f in Path(cfg["paths"]["work"]).rglob("*.docx"):
+        f.unlink()
+        console.log(f"Deleted {f}")
     media_dir = Path(cfg["paths"]["wiki"]) / "assets" / "media"
     if media_dir.exists():
         rmtree(media_dir)

--- a/tests/test_reset_work_dir.py
+++ b/tests/test_reset_work_dir.py
@@ -42,6 +42,14 @@ def test_reset_work_dir(tmp_path, monkeypatch):
     doc_file = paths["originals"] / "sample.docx"
     _create_doc(doc_file)
 
+    # Extra DOCX files inside work directory to verify cleanup
+    extra_docx = paths["work"] / "orphan.docx"
+    _create_doc(extra_docx)
+    subdir = paths["work"] / "sub"
+    subdir.mkdir(parents=True, exist_ok=True)
+    nested_docx = subdir / "nested.docx"
+    _create_doc(nested_docx)
+
     monkeypatch.setattr("subprocess.run", _fake_run)
     monkeypatch.setattr("wiki.processing.docx_to_md.ensure_pandoc", lambda: None)
     monkeypatch.setattr("wiki.cli.ensure_pandoc", lambda: None)
@@ -63,4 +71,8 @@ def test_reset_work_dir(tmp_path, monkeypatch):
     for pattern in ["*.md", "*.yaml", "*.csv"]:
         assert not list(paths["work"].rglob(pattern))
         assert not list(paths["wiki"].rglob(pattern))
+
+    # Ensure DOCX files were removed from work directory
+    assert not extra_docx.exists()
+    assert not nested_docx.exists()
 


### PR DESCRIPTION
## Summary
- add `work/` and `inputs/` directories to `.gitignore`
- remove `.docx` files from `work` when running `wiki reset`
- update the `wiki reset` docs
- test docx cleanup

## Testing
- `poetry install --with dev`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bb7417308333865265c4ccc8008f