### PR TITLE
Implement auto-index for orphan docs

### DIFF
--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -11,6 +11,7 @@ from .processing.docx_to_md import convert_docx_to_md
 from .processing.headings_map import build_headings_map, save_map_yaml
 from .processing.ingest import ingest_content
 from .processing.sidebar import build_sidebar
+from .tools.auto_index import auto_index_missing
 from .processing.reclassify import reclassify_unclassified
 from .processing.search_index import build_search_index
 from rich.progress import track
@@ -426,4 +427,22 @@ def move_cleaned_to_process() -> None:
     for f in cleaned_dir.glob("*.docx"):
         copyfile(f, process_dir / f.name)
         print(f"\u2713 {f.name} → {process_dir}")
+
+
+@app.command("auto-index-missing")
+def auto_index_missing_cli(
+    set_visible: bool = typer.Option(
+        False,
+        "--set-visible",
+        help="Marcar como visibles los documentos añadidos",
+    )
+) -> None:
+    """Añade al index los archivos Markdown no listados."""
+    index_path = cfg["paths"]["work"] / "index.yaml"
+    wiki_dir = cfg["paths"]["wiki"]
+    added = auto_index_missing(index_path, wiki_dir, set_visible=set_visible)
+    if added:
+        typer.echo(f"{len(added)} nuevos documentos añadidos al índice")
+    else:
+        typer.echo("No se encontraron documentos huérfanos")
 

--- a/src/wiki/processing/sidebar.py
+++ b/src/wiki/processing/sidebar.py
@@ -42,25 +42,28 @@ def _traverse_index(
     max_slug_len: int | None,
 ) -> None:
     for entry in entries:
+        if not entry.get("visible", True):
+            continue
         title = entry.get("title", "")
         slug = entry.get("slug")
-        if not slug:
+        if slug and exclude_prefix and slug.startswith(exclude_prefix):
             continue
-        if exclude_prefix and slug.startswith(exclude_prefix):
-            continue
-        if max_slug_len and len(slug) > max_slug_len:
+        if slug and max_slug_len and len(slug) > max_slug_len:
             continue
         if len(title.split()) > 25:
             continue
-        filename = f"{slug}.md"
-        path = wiki_dir / filename
-        if not title or not _has_valid_title(path):
+        filename = f"{slug}.md" if slug else None
+        path = wiki_dir / filename if filename else None
+        if not title or (path and not _has_valid_title(path)):
             continue
-        link = f"/wiki/{filename}" if absolute else filename
         indent = "  " * (level - 1)
         if len(title) > 100:
             title = title[:97].rstrip() + "..."
-        lines.append(f"{indent}* [{title}]({link})")
+        if slug:
+            link = f"/wiki/{filename}" if absolute else filename
+            lines.append(f"{indent}* [{title}]({link})")
+        else:
+            lines.append(f"{indent}* {title}")
         children = entry.get("children") or []
         _traverse_index(
             children,
@@ -84,6 +87,30 @@ def build_sidebar(
     """Generate a Docsify sidebar from index.yaml applying simple filters."""
     with index_path.open(encoding="utf-8") as f:
         index_data = yaml.safe_load(f) or []
+
+    # Detect new format with sections/pages
+    if index_data and "section" in index_data[0]:
+        converted: list[dict] = []
+        for i, section in enumerate(index_data, start=1):
+            sec_entry = {
+                "id": str(i),
+                "title": section.get("section", ""),
+                "slug": None,
+                "children": [],
+            }
+            for j, page in enumerate(section.get("pages", []), start=1):
+                slug = Path(page.get("path", "")).stem
+                sec_entry["children"].append(
+                    {
+                        "id": f"{i}.{j}",
+                        "title": page.get("title", ""),
+                        "slug": slug,
+                        "visible": page.get("visible", True),
+                        "children": [],
+                    }
+                )
+            converted.append(sec_entry)
+        index_data = converted
 
     lines: list[str] = []
     _traverse_index(

--- a/src/wiki/tools/auto_index.py
+++ b/src/wiki/tools/auto_index.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+
+
+def load_index(index_path: Path) -> list[dict]:
+    """Load index.yaml returning a list."""
+    if index_path.exists():
+        with index_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or []
+    else:
+        data = []
+    return data
+
+
+def save_index(index_path: Path, data: list[dict]) -> None:
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    with index_path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, allow_unicode=True)
+
+
+def _collect_paths(data: list[dict]) -> set[str]:
+    paths: set[str] = set()
+    for section in data:
+        for page in section.get("pages", []):
+            p = page.get("path")
+            if p:
+                paths.add(p)
+    return paths
+
+
+def auto_index_missing(index_path: Path, wiki_dir: Path, *, set_visible: bool = False) -> list[str]:
+    """Add markdown files missing from index.yaml under a final section.
+
+    Returns a list of added file names.
+    """
+    data = load_index(index_path)
+    indexed = _collect_paths(data)
+
+    md_files = [p.name for p in wiki_dir.glob("*.md") if p.name not in {"_sidebar.md"}]
+    missing = sorted(f for f in md_files if f not in indexed)
+    if not missing:
+        return []
+
+    new_pages = []
+    for filename in missing:
+        title = Path(filename).stem.replace("-", " ").capitalize()
+        new_pages.append({"title": title, "path": filename, "visible": bool(set_visible)})
+
+    section_title = "99. Documentos no indexados"
+    for section in data:
+        if section.get("section") == section_title:
+            section.setdefault("pages", []).extend(new_pages)
+            break
+    else:
+        data.append({"section": section_title, "pages": new_pages})
+
+    save_index(index_path, data)
+    return missing

--- a/tests/test_auto_index.py
+++ b/tests/test_auto_index.py
@@ -1,0 +1,35 @@
+import yaml
+from typer.testing import CliRunner
+from wiki.cli import app
+from wiki.tools.auto_index import auto_index_missing
+
+runner = CliRunner()
+
+def test_auto_index_missing(tmp_path):
+    wiki_dir = tmp_path / "wiki"
+    wiki_dir.mkdir()
+    (wiki_dir / "a.md").write_text("# A\n", encoding="utf-8")
+    (wiki_dir / "b.md").write_text("# B\n", encoding="utf-8")
+    index_path = tmp_path / "index.yaml"
+    data = [{"section": "Sec", "pages": [{"title": "A", "path": "a.md", "visible": True}]}]
+    index_path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
+
+    missing = auto_index_missing(index_path, wiki_dir)
+    assert missing == ["b.md"]
+    result = yaml.safe_load(index_path.read_text(encoding="utf-8"))
+    last = result[-1]
+    assert last["section"] == "99. Documentos no indexados"
+    assert any(p["path"] == "b.md" and p["visible"] is False for p in last["pages"])
+
+
+def test_cli_auto_index_missing(tmp_path, monkeypatch):
+    wiki_dir = tmp_path / "wiki"
+    wiki_dir.mkdir()
+    (wiki_dir / "a.md").write_text("# A\n", encoding="utf-8")
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr("wiki.cli.cfg", {"paths": {"work": tmp_path, "wiki": wiki_dir}})
+    result = runner.invoke(app, ["auto-index-missing", "--set-visible"])
+    assert result.exit_code == 0
+    data = yaml.safe_load(index_path.read_text(encoding="utf-8"))
+    assert data[0]["pages"][0]["visible"] is True

--- a/tests/test_sidebar_visible.py
+++ b/tests/test_sidebar_visible.py
@@ -1,0 +1,29 @@
+import yaml
+from wiki.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_sidebar_visible_flag(tmp_path, monkeypatch):
+    index_data = [
+        {
+            "section": "Sec",
+            "pages": [
+                {"title": "A", "path": "a.md", "visible": True},
+                {"title": "B", "path": "b.md", "visible": False},
+            ],
+        }
+    ]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
+    paths = {"work": tmp_path, "wiki": tmp_path}
+    monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
+
+    (tmp_path / "a.md").write_text("# Title\n", encoding="utf-8")
+    (tmp_path / "b.md").write_text("# Title\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["sidebar"])
+    assert result.exit_code == 0
+    content = (tmp_path / "_sidebar.md").read_text(encoding="utf-8").splitlines()
+    assert content == ["* Sec", "  * [A](a.md)"]


### PR DESCRIPTION
## Summary
- add tool to update index.yaml with missing wiki Markdown files
- support `visible` flag in sidebar generation
- expose `auto-index-missing` command in CLI
- test auto indexing and visibility logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c30a30f08333800d671c1b3d4035