### PR TITLE
Implement conditional heading detection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,13 @@
 paths:
-  originals: "work/to_process"
-  cleaned_input: "inputs/_originals"
-  cleaned_output: "work/cleaned"
+  originals: "inputs/_originals"
+  cleaned: "work/cleaned"
+  to_process: "work/to_process"
   work: "work"
   wiki: "wiki"
   tmp: "work/tmp"
 
 options:
+  allow_heading_heuristics: true
+  fallback_to_heuristics_for_pdf: true
   ocr: false
   cutoff_similarity: 0.5

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -99,10 +99,10 @@ def full(
         console.print(str(exc), style="red")
         raise typer.Exit(code=1)
 
-    originals_dir = cfg["paths"]["originals"]
-    docx_files = sorted(originals_dir.glob("*.docx"))
+    source_dir = cfg["paths"]["to_process"]
+    docx_files = sorted(source_dir.glob("*.docx"))
     if not docx_files:
-        console.print("No DOCX files found in originals directory", style="red")
+        console.print("No DOCX files found in to_process directory", style="red")
         raise typer.Exit(code=1)
 
     norm_dir = cfg["paths"]["work"] / "normalized"
@@ -369,7 +369,7 @@ def clean_docx_batch() -> None:
     from .tools.clean_docx import batch_process_directory
 
     input_dir = Path(cfg["paths"]["originals"])
-    output_dir = Path(cfg["paths"]["work"]) / "cleaned"
+    output_dir = Path(cfg["paths"]["cleaned"])
     output_dir.mkdir(parents=True, exist_ok=True)
 
     batch_process_directory(input_dir, output_dir)
@@ -385,16 +385,16 @@ def preprocess_docs_batch(
     """Limpia y convierte documentos .docx y .pdf en formato procesable."""
     from .tools.preprocess_documents import batch_process_directory
 
-    input_dir = Path(cfg["paths"]["cleaned_input"])
-    output_dir = Path(cfg["paths"]["cleaned_output"])
+    input_dir = Path(cfg["paths"]["originals"])
+    output_dir = Path(cfg["paths"]["cleaned"])
     output_dir.mkdir(parents=True, exist_ok=True)
 
     batch_process_directory(input_dir, output_dir)
     typer.echo(f"\u2705 Documentos limpios generados en: {output_dir}")
 
     # Copia automática de documentos limpios al directorio de entrada para wiki full
-    to_process_dir = Path(cfg["paths"]["originals"])
-    cleaned_dir = Path(cfg["paths"]["cleaned_output"])
+    to_process_dir = Path(cfg["paths"]["to_process"])
+    cleaned_dir = Path(cfg["paths"]["cleaned"])
 
     to_process_dir.mkdir(parents=True, exist_ok=True)
     copied_files = 0
@@ -420,8 +420,8 @@ def move_cleaned_to_process() -> None:
     cfg_path = Path("config.yaml")
     cfg = safe_load(cfg_path.read_text(encoding="utf-8"))
 
-    cleaned_dir = Path(cfg["paths"]["cleaned_output"])
-    process_dir = Path(cfg["paths"]["originals"])
+    cleaned_dir = Path(cfg["paths"]["cleaned"])
+    process_dir = Path(cfg["paths"]["to_process"])
     process_dir.mkdir(parents=True, exist_ok=True)
 
     for f in cleaned_dir.glob("*.docx"):

--- a/src/wiki/processing/normalization_utils.py
+++ b/src/wiki/processing/normalization_utils.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from docx.text.paragraph import Paragraph
+
+from .style_map import HEADINGS_RULES
+
+
+def detect_heading_by_heuristics(p: Paragraph) -> int:
+    """Return heading level detected using visual heuristics."""
+    for run in p.runs:
+        for style, rule in HEADINGS_RULES.items():
+            if rule(run):
+                try:
+                    return int(style.split()[1])
+                except (IndexError, ValueError):
+                    return 0
+    return 0
+
+
+def detect_heading_by_style(p: Paragraph) -> int:
+    """Return heading level based on explicit paragraph style."""
+    name = p.style.name if p.style else ""
+    if name.startswith("Heading"):
+        try:
+            return int(name.split()[1])
+        except (IndexError, ValueError):
+            return 0
+    return 0
+
+
+def is_converted_from_pdf(doc_path: Path) -> bool:
+    """Heuristically determine if a docx originated from a PDF conversion."""
+    name = doc_path.name.lower()
+    parent = str(doc_path.parent).lower()
+    return "pdf" in name or "pdf" in parent
+
+
+def should_use_heuristics(doc_path: Path, config: dict) -> bool:
+    """Decide if heading heuristics should be used for a given document."""
+    opts = config.get("options", {})
+    if opts.get("allow_heading_heuristics", False):
+        return True
+    if opts.get("fallback_to_heuristics_for_pdf", False):
+        return is_converted_from_pdf(doc_path)
+    return False

--- a/src/wiki/processing/normalize_docx.py
+++ b/src/wiki/processing/normalize_docx.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 from docx import Document
 
-from .style_map import HEADINGS_RULES
+from .normalization_utils import (
+    detect_heading_by_heuristics,
+    detect_heading_by_style,
+    should_use_heuristics,
+)
 
 
 def _remove_toc_paragraphs(document: Document) -> None:
@@ -16,18 +20,25 @@ def _remove_toc_paragraphs(document: Document) -> None:
             element.getparent().remove(element)
 
 
-def normalize_styles(doc_path: Path, out_path: Path) -> None:
+def normalize_styles(doc_path: Path, out_path: Path, cfg: dict | None = None) -> None:
     """Normalize visual styles to structured heading styles in a DOCX file."""
+    if cfg is None:  # pragma: no cover - used by CLI
+        from ..config import cfg as default_cfg
+
+        cfg = default_cfg
+
     document = Document(str(doc_path))
     _remove_toc_paragraphs(document)
+
+    use_heuristics = should_use_heuristics(doc_path, cfg)
+
     for paragraph in document.paragraphs:
-        for run in paragraph.runs:
-            for style, rule in HEADINGS_RULES.items():
-                if rule(run):
-                    paragraph.style = style
-                    break
-            else:
-                continue
-            break
+        if use_heuristics:
+            level = detect_heading_by_heuristics(paragraph)
+        else:
+            level = detect_heading_by_style(paragraph)
+        if level:
+            paragraph.style = f"Heading {level}"
+
     out_path.parent.mkdir(parents=True, exist_ok=True)
     document.save(str(out_path))

--- a/src/wiki/tools/preprocess_documents.py
+++ b/src/wiki/tools/preprocess_documents.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     cfg_path = Path("config.yaml")
     cfg = safe_load(cfg_path.read_text(encoding="utf-8"))
 
-    input_dir = Path(cfg["paths"]["cleaned_input"])
-    output_dir = Path(cfg["paths"]["cleaned_output"])
+    input_dir = Path(cfg["paths"]["originals"])
+    output_dir = Path(cfg["paths"]["cleaned"])
     output_dir.mkdir(parents=True, exist_ok=True)
     batch_process_directory(input_dir, output_dir)

--- a/tests/test_clean_docx.py
+++ b/tests/test_clean_docx.py
@@ -34,11 +34,11 @@ def test_cli_clean_docx(tmp_path, monkeypatch):
     work.mkdir()
     doc_in = orig / "sample.docx"
     _create_dirty_docx(doc_in)
-    paths = {"originals": orig, "work": work}
+    paths = {"originals": orig, "cleaned": work / "cleaned", "work": work}
     monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
     result = runner.invoke(app, ["clean-docx"])
     assert result.exit_code == 0
-    cleaned = work / "cleaned" / "sample.docx"
+    cleaned = paths["cleaned"] / "sample.docx"
     assert cleaned.exists()
     doc = Document(cleaned)
     assert doc.paragraphs[0].style.name == "Heading 1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ def test_full_calls_ensure_pandoc(monkeypatch, tmp_path):
     monkeypatch.setattr("wiki.cli.ensure_pandoc", dummy)
 
     paths = {
-        "originals": tmp_path / "orig",
+        "to_process": tmp_path / "orig",
         "work": tmp_path / "work",
         "wiki": tmp_path / "wiki",
         "tmp": tmp_path / "tmp",
@@ -34,7 +34,7 @@ def test_full_calls_ensure_pandoc(monkeypatch, tmp_path):
     for p in paths.values():
         p.mkdir(parents=True, exist_ok=True)
 
-    doc_path = paths["originals"] / "sample.docx"
+    doc_path = paths["to_process"] / "sample.docx"
     doc = Document()
     run = doc.add_paragraph().add_run("Title")
     run.bold = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,14 +9,16 @@ def test_load_config_creates_directories(tmp_path, monkeypatch):
     (root / "src/wiki").mkdir(parents=True)
     config_yaml = (
         "paths:\n"
-        "  originals: 'work/to_process'\n"
-        "  cleaned_input: 'inputs/_originals'\n"
-        "  cleaned_output: 'work/cleaned'\n"
+        "  originals: 'inputs/_originals'\n"
+        "  cleaned: 'work/cleaned'\n"
+        "  to_process: 'work/to_process'\n"
         "  work: 'work'\n"
         "  wiki: 'wiki'\n"
         "  tmp: 'work/tmp'\n"
         "\n"
         "options:\n"
+        "  allow_heading_heuristics: true\n"
+        "  fallback_to_heuristics_for_pdf: true\n"
         "  ocr: false\n"
         "  cutoff_similarity: 0.5\n"
     )

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -37,7 +37,7 @@ def _fake_run(cmd, capture_output=True, text=True, encoding="utf-8"):
 
 def test_package_static(tmp_path, monkeypatch):
     paths = {
-        "originals": tmp_path / "orig",
+        "to_process": tmp_path / "orig",
         "work": tmp_path / "work",
         "wiki": tmp_path / "wiki",
         "tmp": tmp_path / "tmp",
@@ -45,7 +45,7 @@ def test_package_static(tmp_path, monkeypatch):
     for p in paths.values():
         p.mkdir(parents=True, exist_ok=True)
 
-    doc_path = paths["originals"] / "sample.docx"
+    doc_path = paths["to_process"] / "sample.docx"
     _create_doc(doc_path)
 
     monkeypatch.setattr("subprocess.run", _fake_run)

--- a/tests/test_pipeline_doc_sources.py
+++ b/tests/test_pipeline_doc_sources.py
@@ -12,7 +12,7 @@ runner = CliRunner()
 
 def test_full_multiple_doc_sources(tmp_path, monkeypatch):
     paths = {
-        "originals": tmp_path / "orig",
+        "to_process": tmp_path / "orig",
         "work": tmp_path / "work",
         "wiki": tmp_path / "wiki",
         "tmp": tmp_path / "tmp",
@@ -20,8 +20,8 @@ def test_full_multiple_doc_sources(tmp_path, monkeypatch):
     for p in paths.values():
         p.mkdir(parents=True, exist_ok=True)
 
-    doc_a = paths["originals"] / "DocA.docx"
-    doc_b = paths["originals"] / "DocB.docx"
+    doc_a = paths["to_process"] / "DocA.docx"
+    doc_b = paths["to_process"] / "DocB.docx"
 
     for doc_path, text in [(doc_a, "A"), (doc_b, "B")]:
         doc = Document()

--- a/tests/test_pipeline_full.py
+++ b/tests/test_pipeline_full.py
@@ -10,7 +10,7 @@ runner = CliRunner()
 
 def test_pipeline_full(tmp_path, monkeypatch):
     paths = {
-        "originals": tmp_path / "orig",
+        "to_process": tmp_path / "orig",
         "work": tmp_path / "work",
         "wiki": tmp_path / "wiki",
         "tmp": tmp_path / "tmp",
@@ -18,7 +18,7 @@ def test_pipeline_full(tmp_path, monkeypatch):
     for p in paths.values():
         p.mkdir(parents=True, exist_ok=True)
 
-    doc_path = paths["originals"] / "sample.docx"
+    doc_path = paths["to_process"] / "sample.docx"
     doc = Document()
     run = doc.add_paragraph().add_run("Title")
     run.bold = True
@@ -52,7 +52,7 @@ def test_pipeline_full(tmp_path, monkeypatch):
 
 def test_pipeline_full_with_image(tmp_path, monkeypatch):
     paths = {
-        "originals": tmp_path / "orig",
+        "to_process": tmp_path / "orig",
         "work": tmp_path / "work",
         "wiki": tmp_path / "wiki",
         "tmp": tmp_path / "tmp",
@@ -60,7 +60,7 @@ def test_pipeline_full_with_image(tmp_path, monkeypatch):
     for p in paths.values():
         p.mkdir(parents=True, exist_ok=True)
 
-    doc_path = paths["originals"] / "img.docx"
+    doc_path = paths["to_process"] / "img.docx"
     doc = Document()
     run = doc.add_paragraph().add_run("Title")
     run.bold = True

--- a/tests/test_preprocess_documents.py
+++ b/tests/test_preprocess_documents.py
@@ -45,27 +45,27 @@ def test_cli_preprocess_docs(tmp_path, monkeypatch):
 
     monkeypatch.setattr("wiki.tools.preprocess_documents.Converter", DummyConverter)
     paths = {
-        "cleaned_input": orig,
-        "cleaned_output": work / "cleaned",
-        "originals": work / "to_process",
+        "originals": orig,
+        "cleaned": work / "cleaned",
+        "to_process": work / "to_process",
     }
     monkeypatch.setattr("wiki.cli.cfg", {"paths": paths})
 
     result = runner.invoke(app, ["preprocess-docs"])
     assert result.exit_code == 0
 
-    cleaned = work / "cleaned" / "sample.docx"
+    cleaned = paths["cleaned"] / "sample.docx"
     assert cleaned.exists()
     doc = Document(cleaned)
     assert doc.paragraphs[0].style.name.startswith("Heading")
 
-    pdf_cleaned = work / "cleaned" / "sample_pdf.docx"
+    pdf_cleaned = paths["cleaned"] / "sample_pdf.docx"
     assert pdf_cleaned.exists()
     pdf_doc = Document(pdf_cleaned)
     assert pdf_doc.paragraphs[0].style.name == "Heading 1"
 
     # Cleaned files should be automatically copied for processing
-    doc_copied = work / "to_process" / "sample.docx"
-    pdf_copied = work / "to_process" / "sample_pdf.docx"
+    doc_copied = paths["to_process"] / "sample.docx"
+    pdf_copied = paths["to_process"] / "sample_pdf.docx"
     assert doc_copied.exists()
     assert pdf_copied.exists()

--- a/tests/test_reset_work_dir.py
+++ b/tests/test_reset_work_dir.py
@@ -31,7 +31,7 @@ def _fake_run(cmd, capture_output=True, text=True, encoding="utf-8"):
 
 def test_reset_work_dir(tmp_path, monkeypatch):
     paths = {
-        "originals": tmp_path / "orig",
+        "to_process": tmp_path / "orig",
         "work": tmp_path / "work",
         "wiki": tmp_path / "wiki",
         "tmp": tmp_path / "tmp",
@@ -39,7 +39,7 @@ def test_reset_work_dir(tmp_path, monkeypatch):
     for p in paths.values():
         p.mkdir(parents=True, exist_ok=True)
 
-    doc_file = paths["originals"] / "sample.docx"
+    doc_file = paths["to_process"] / "sample.docx"
     _create_doc(doc_file)
 
     # Extra DOCX files inside work directory to verify cleanup


### PR DESCRIPTION
## Summary
- allow configuring heuristics vs style-based heading detection
- enable pdf-based fallback detection
- adjust CLI and preprocessing scripts for new path names
- update test suite for new config keys
- add normalization utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d698a2588333923415ddd36785b5