### PR TITLE
Implement OCR fallback for PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Wiki Documental provides an automated workflow for turning a collection of DOCX 
 poetry install --with dev
 ```
 
+Install system dependencies for PDF and OCR processing:
+
+- **Windows**: install Tesseract OCR and Poppler for Windows, then add their
+  `bin/` directories to your `PATH`.
+- **Linux**:
+
+  ```bash
+  sudo apt install tesseract-ocr poppler-utils
+  ```
+
 ## Quick start
 
 Place your source `.docx` files in `inputs/_originals/` and run the full pipeline:

--- a/config.yaml
+++ b/config.yaml
@@ -9,5 +9,5 @@ paths:
 options:
   allow_heading_heuristics: true
   fallback_to_heuristics_for_pdf: true
-  ocr: false
+  ocr: true
   cutoff_similarity: 0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,10 @@ python-slugify = "^8.0"
 tqdm = "^4.66"
 typer = {version = "^0.12", extras = ["all"]}
 "pdfminer.six" = {version = "^20221105", optional = true}
-pdf2image = {version = "^1.17", optional = true}
-pytesseract = {version = "^0.3", optional = true}
+pdf2image = "^1.16.3"
+pytesseract = "^0.3.10"
 pdf2docx = "^0.5.6"
+Pillow = "^10.0.1"
 
 [tool.poetry.extras]
 pdf = ["pdfminer.six", "pdf2image", "pytesseract"]

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -389,7 +389,7 @@ def preprocess_docs_batch(
     output_dir = Path(cfg["paths"]["cleaned"])
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    batch_process_directory(input_dir, output_dir)
+    batch_process_directory(input_dir, output_dir, cfg)
     typer.echo(f"\u2705 Documentos limpios generados en: {output_dir}")
 
     # Copia automática de documentos limpios al directorio de entrada para wiki full

--- a/src/wiki/tools/preprocess_documents.py
+++ b/src/wiki/tools/preprocess_documents.py
@@ -3,6 +3,8 @@ import docx
 from docx.document import Document
 from docx.text.paragraph import Paragraph
 from pdf2docx import Converter
+from pdf2image import convert_from_path
+from pytesseract import image_to_string
 from yaml import safe_load
 
 # --- Heurísticas de detección de encabezados ---
@@ -62,8 +64,40 @@ def clean_docx_styles(doc_path: Path, output_path: Path) -> bool:
     return changes_made
 
 
-def batch_process_directory(input_dir: Path, output_dir: Path):
+def process_pdf_with_converter(pdf_path: Path, output_docx_path: Path) -> None:
+    """Convertir PDF a DOCX usando pdf2docx."""
+    print(f"🧪 Intentando conversión directa para {pdf_path.name}")
+    converter = Converter(str(pdf_path))
+    converter.convert(str(output_docx_path), start=0, end=None)
+    converter.close()
+
+
+def process_pdf_with_ocr(pdf_path: Path, output_dir: Path) -> None:
+    """Extrae texto e imágenes de un PDF usando OCR."""
+    print(f"🧠 Ejecutando OCR para {pdf_path.name}")
+    pages = convert_from_path(str(pdf_path))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    assets_dir = output_dir / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    md_path = output_dir / f"{pdf_path.stem}.md"
+    with md_path.open("w", encoding="utf-8") as md:
+        for idx, img in enumerate(pages, start=1):
+            text = image_to_string(img)
+            md.write(f"## P\xE1gina {idx}\n\n")
+            md.write(text.strip() + "\n\n")
+            img_name = f"{pdf_path.stem}_page_{idx:03}.png"
+            img_path = assets_dir / img_name
+            img.save(img_path)
+            md.write(f"![P\xE1gina {idx}](assets/{img_name})\n\n")
+
+
+def batch_process_directory(input_dir: Path, output_dir: Path, cfg: dict | None = None):
     print(f"\n\U0001f4c2 Procesando documentos desde: {input_dir}")
+    ocr_enabled = False
+    ocr_dir = output_dir.parent / "ocr_outputs"
+    if cfg:
+        ocr_enabled = cfg.get("options", {}).get("ocr", False)
+        ocr_dir = Path(cfg["paths"].get("work", output_dir.parent)) / "ocr_outputs"
     for file in sorted(input_dir.glob("*")):
         print(f"\n\U0001f4dd {file.name}")
         output_file = output_dir / (file.stem + ".docx")
@@ -73,13 +107,13 @@ def batch_process_directory(input_dir: Path, output_dir: Path):
 
         elif file.suffix.lower() == ".pdf":
             try:
-                print("   → Convirtiendo PDF a DOCX...")
-                converter = Converter(str(file))
-                converter.convert(str(output_file), start=0, end=None)
-                converter.close()
+                if ocr_enabled:
+                    raise RuntimeError("Forzando OCR por configuración")
+                process_pdf_with_converter(file, output_file)
                 clean_docx_styles(output_file, output_file)
             except Exception as e:
                 print(f"\u274c Error al convertir {file.name}: {e}")
+                process_pdf_with_ocr(file, ocr_dir)
 
     print("\n\u2705 Limpieza completada.")
 
@@ -91,4 +125,4 @@ if __name__ == "__main__":
     input_dir = Path(cfg["paths"]["originals"])
     output_dir = Path(cfg["paths"]["cleaned"])
     output_dir.mkdir(parents=True, exist_ok=True)
-    batch_process_directory(input_dir, output_dir)
+    batch_process_directory(input_dir, output_dir, cfg)


### PR DESCRIPTION
## Summary
- enable OCR option in config
- add pdf/OCR dependencies
- document system dependencies for OCR
- implement OCR fallback in `preprocess_documents.py`
- update CLI to pass config to preprocessing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852de7995c48333b70ce44a45829c69