### PR TITLE
Implement menu improvements

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,10 @@ options:
   fallback_to_heuristics_for_pdf: true
   ocr: true
   cutoff_similarity: 0.5
+  discard_sections:
+    portada: true
+    indice: true
+    contraportada: true
 
 menu:
   depth_limit: 2

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -174,7 +174,14 @@ def full(
     cutoff = float(cfg.get("options", {}).get("cutoff_similarity", 0.5))
 
     for md in track(sorted(md_raw_dir.glob("*.md")), description="Ingest"):
-        ingest_content(md, index_path, wiki_dir, cutoff=cutoff, doc_source=md.stem)
+        ingest_content(
+            md,
+            index_path,
+            wiki_dir,
+            cutoff=cutoff,
+            doc_source=md.stem,
+            cfg=cfg,
+        )
 
     console.print("[bold]Generating sidebar...[/bold]")
     abs_links = ctx.obj.get("absolute_links", False) if ctx.obj else False
@@ -255,6 +262,7 @@ def index(
         False, "--overwrite", "-o", help="Overwrite existing index.yaml"
     ),
     flat: bool = typer.Option(False, "--flat", help="Generate flat two-level index"),
+    depth: int = typer.Option(None, "--depth", "-d", help="Depth limit for index"),
 ) -> None:
     """Create index.yaml from map.yaml."""
     out_file = cfg["paths"]["work"] / "index.yaml"
@@ -281,7 +289,7 @@ def index(
                         {"level": item["level"], "title": item["title"], "slug": item["slug"]}
                     )
     else:
-        index_data = build_index_from_map(map_data)
+        index_data = build_index_from_map(map_data, max_depth=depth)
     out_file.parent.mkdir(parents=True, exist_ok=True)
     with out_file.open("w", encoding="utf-8") as f:
         yaml.safe_dump(index_data, f, allow_unicode=True)
@@ -319,7 +327,14 @@ def ingest(file: Path) -> None:
     wiki_dir = cfg["paths"]["wiki"]
     cutoff = float(cfg.get("options", {}).get("cutoff_similarity", 0.5))
     doc_source = file.stem
-    ingest_content(file, index_path, wiki_dir, cutoff=cutoff, doc_source=doc_source)
+    ingest_content(
+        file,
+        index_path,
+        wiki_dir,
+        cutoff=cutoff,
+        doc_source=doc_source,
+        cfg=cfg,
+    )
     typer.echo("Content ingested")
 
 

--- a/src/wiki/processing/index_builder.py
+++ b/src/wiki/processing/index_builder.py
@@ -3,18 +3,24 @@ from __future__ import annotations
 from typing import List, Dict, Any
 import re
 
-MAX_LEVEL = 2
+from wiki.config import cfg
+from wiki.utils.slug import slug_to_label
 
 
-def build_index_from_map(map_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def build_index_from_map(
+    map_data: List[Dict[str, Any]],
+    max_depth: int | None = None,
+) -> List[Dict[str, Any]]:
     """Generate hierarchical index data from headings map."""
+    if max_depth is None:
+        max_depth = int(cfg.get("menu", {}).get("depth_limit", 2))
     index: List[Dict[str, Any]] = []
     stack: List[tuple[int, Dict[str, Any]]] = []
     counters: dict[int, int] = {}
 
     for item in map_data:
         level = int(item.get("level", 1))
-        if level > MAX_LEVEL:
+        if level > max_depth:
             continue
         title = str(item.get("title", ""))
         title_clean = re.sub(r"!\[[^\]]*\]\([^\)]+\)", "", title)
@@ -26,10 +32,13 @@ def build_index_from_map(map_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]
             if l > level:
                 del counters[l]
         id_parts = [str(counters[i]) for i in range(1, level + 1) if i in counters]
+        slug = item.get("slug")
         entry = {
             "id": ".".join(id_parts),
             "title": item.get("title"),
-            "slug": item.get("slug"),
+            "slug": slug,
+            "label": slug_to_label(str(slug)) if slug else None,
+            "visible": True,
             "children": [],
         }
         while stack and stack[-1][0] >= level:

--- a/src/wiki/processing/ingest.py
+++ b/src/wiki/processing/ingest.py
@@ -16,6 +16,28 @@ from .md_post import (
     normalize_image_paths,
 )
 
+DEFAULT_DISCARD = {
+    "portada": True,
+    "indice": True,
+    "contraportada": True,
+}
+
+
+def _should_discard(title: str | None, lines: List[str], cfg: dict) -> bool:
+    opts = cfg.get("options", {}).get("discard_sections", DEFAULT_DISCARD)
+    text = " ".join(l.strip() for l in lines).lower()
+    word_count = len(re.findall(r"\w+", text))
+    if opts.get("portada", True) and title == "__intro__" and word_count < 300:
+        if any(k in text for k in ("presentacion", "versi", "fecha", "document")):
+            return True
+    if opts.get("indice", True) and "..." in text:
+        if any(k in text for k in ("indice", "contents", "tabla de contenidos")):
+            return True
+    if opts.get("contraportada", True) and word_count < 200:
+        if any(k in text for k in ("firma", "autor", "revision", "confidencial")):
+            return True
+    return False
+
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
 
 
@@ -130,8 +152,15 @@ def ingest_content(
     out_dir: Path,
     cutoff: float = 0.5,
     doc_source: str | Path | None = None,
+    *,
+    cfg: dict | None = None,
 ) -> None:
     """Fragment markdown file according to index.yaml and store pieces."""
+    if cfg is None:  # pragma: no cover - default config
+        from wiki.config import cfg as default_cfg
+
+        cfg = default_cfg
+
     with index_path.open("r", encoding="utf-8") as f:
         index_data = yaml.safe_load(f) or []
     entries = _flatten_index(index_data)
@@ -143,6 +172,8 @@ def ingest_content(
     untitled_count = 1
 
     for title, lines in sections:
+        if _should_discard(title, lines, cfg):
+            continue
         if title == "__intro__":
             new_title = f"Seccion sin titulo {untitled_count}"
             untitled_count += 1

--- a/src/wiki/processing/sidebar.py
+++ b/src/wiki/processing/sidebar.py
@@ -41,7 +41,7 @@ def _traverse_index(
     exclude_prefix: str | None,
     max_slug_len: int | None,
 ) -> None:
-    for entry in entries:
+    for entry in sorted(entries, key=lambda e: str(e.get("title", "")).lower()):
         if not entry.get("visible", True):
             continue
         title = entry.get("title", "")
@@ -61,6 +61,8 @@ def _traverse_index(
             title = title[:97].rstrip() + "..."
         if slug:
             link = f"/wiki/{filename}" if absolute else filename
+            if level == 1 and lines:
+                lines.append("---")
             lines.append(f"{indent}* [{title}]({link})")
         else:
             lines.append(f"{indent}* {title}")
@@ -111,6 +113,13 @@ def build_sidebar(
                 )
             converted.append(sec_entry)
         index_data = converted
+
+    def sort_entries(entries: list[dict]) -> None:
+        entries.sort(key=lambda e: str(e.get("title", "")).lower())
+        for ent in entries:
+            sort_entries(ent.get("children") or [])
+
+    sort_entries(index_data)
 
     lines: list[str] = []
     _traverse_index(

--- a/src/wiki/utils/slug.py
+++ b/src/wiki/utils/slug.py
@@ -19,3 +19,10 @@ def safe_slug(text: str, used: set[str]) -> str:
         slug = f"{base}-{count}"
     used.add(slug)
     return slug
+
+
+def slug_to_label(slug: str) -> str:
+    """Return a human friendly label derived from ``slug``."""
+    slug = re.sub(r"^[0-9]+-", "", slug)
+    words = slug.split("-")
+    return " ".join(w.capitalize() for w in words if w)

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -8,8 +8,9 @@ def test_build_index_from_map():
         {"level": 3, "title": "H1.1.1", "slug": "h1-1-1"},
         {"level": 1, "title": "H2", "slug": "h2"},
     ]
-    result = build_index_from_map(map_data)
+    result = build_index_from_map(map_data, max_depth=2)
     assert result[0]["id"] == "1"
     assert result[0]["children"][0]["id"] == "1.1"
     assert not result[0]["children"][0]["children"]
     assert result[1]["id"] == "2"
+    assert result[0]["visible"] is True

--- a/tests/test_ingest_discard.py
+++ b/tests/test_ingest_discard.py
@@ -1,0 +1,14 @@
+import yaml
+from wiki.processing.ingest import ingest_content
+
+
+def test_discard_intro(tmp_path):
+    md = tmp_path / "full.md"
+    md.write_text("Presentacion del documento\n\n# Real\nTexto\n", encoding="utf-8")
+    index = [{"id": "1", "title": "Real", "slug": "real", "children": []}]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+    out_dir = tmp_path / "wiki"
+    ingest_content(md, index_path, out_dir, cutoff=0.5)
+    assert (out_dir / "real.md").exists()
+    assert not (out_dir / "99_unclassified.md").exists()

--- a/tests/test_slug.py
+++ b/tests/test_slug.py
@@ -1,4 +1,4 @@
-from wiki.utils.slug import safe_slug
+from wiki.utils.slug import safe_slug, slug_to_label
 
 
 def test_safe_slug_uniqueness():
@@ -6,3 +6,8 @@ def test_safe_slug_uniqueness():
     assert safe_slug("T\u00edtulo con acento", used) == "titulo-con-acento"
     assert safe_slug("T\u00edtulo con acento", used) == "titulo-con-acento-2"
     assert safe_slug("T\u00edtulo con acento", used) == "titulo-con-acento-3"
+
+
+def test_slug_to_label():
+    assert slug_to_label("01-introduccion-basica") == "Introduccion Basica"
+    assert slug_to_label("abc-de-fg") == "Abc De Fg"


### PR DESCRIPTION
## Summary
- add slug_to_label helper and tests
- store visibility and label in generated index
- expose depth parameter for `wiki index`
- sort sidebar menu and add separators
- discard intro fragments during ingest
- support discard_sections in config
- test discarding intro fragment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68531325753c833396ca7307165e5635