### PR TITLE
Add docsify preview command

### DIFF
--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -14,6 +14,7 @@ from .processing.sidebar import build_sidebar
 from .tools.auto_index import auto_index_missing
 from .processing.reclassify import reclassify_unclassified
 from .processing.search_index import build_search_index
+from .tools.preview_generator import generate_docsify_preview
 from rich.progress import track
 import yaml
 
@@ -445,4 +446,10 @@ def auto_index_missing_cli(
         typer.echo(f"{len(added)} nuevos documentos añadidos al índice")
     else:
         typer.echo("No se encontraron documentos huérfanos")
+
+
+@app.command("preview")
+def preview_docsify_site() -> None:
+    """Prepara la web estática navegable con Docsify a partir de los .md ya normalizados."""
+    generate_docsify_preview()
 

--- a/src/wiki/tools/preview_generator.py
+++ b/src/wiki/tools/preview_generator.py
@@ -1,0 +1,58 @@
+import shutil
+from pathlib import Path
+
+from wiki.utils.index import render_sidebar_from_index
+
+TEMPLATE_HTML = """<!DOCTYPE html>
+<html>
+<head>
+  <meta charset=\"UTF-8\">
+  <title>Wiki documental</title>
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+</head>
+<body>
+  <div id=\"app\">Cargando...</div>
+  <script>
+    window.$docsify = {
+      name: 'Wiki documental',
+      loadSidebar: true,
+      subMaxLevel: 2,
+    }
+  </script>
+  <script src=\"//unpkg.com/docsify/lib/docsify.min.js\"></script>
+</body>
+</html>
+"""
+
+
+def generate_docsify_preview() -> None:
+    """Genera la carpeta docs_web con archivos Markdown listos para Docsify."""
+    from wiki.cli import cfg
+
+    normalized_dir = Path(cfg["paths"]["wiki"])
+    output_dir = Path("docs_web")
+
+    print(f"\U0001f4e6 Generando vista previa Docsify en: {output_dir.resolve()}")
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    shutil.copytree(normalized_dir, output_dir)
+
+    # Copiar assets de forma explícita si existen
+    assets_src = normalized_dir / "assets"
+    if assets_src.exists():
+        dest = output_dir / "assets"
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(assets_src, dest)
+
+    # Generar _sidebar.md desde index.yaml
+    sidebar_path = output_dir / "_sidebar.md"
+    render_sidebar_from_index(sidebar_path)
+
+    # Generar index.html básico de Docsify
+    (output_dir / "index.html").write_text(TEMPLATE_HTML, encoding="utf-8")
+
+    print("\u2705 Vista previa generada. Ejecuta:")
+    print(f"   cd {output_dir}")
+    print("   python -m http.server")

--- a/src/wiki/utils/index.py
+++ b/src/wiki/utils/index.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from wiki.processing.sidebar import build_sidebar
+
+
+def render_sidebar_from_index(output_path: Path) -> None:
+    """Renderiza _sidebar.md usando index.yaml."""
+    from wiki.cli import cfg
+
+    index_path = Path(cfg["paths"]["work"]) / "index.yaml"
+    build_sidebar(index_path, output_path.parent, absolute_links=False)
+    if output_path.name != "_sidebar.md":
+        (output_path.parent / "_sidebar.md").replace(output_path)

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,36 @@
+import yaml
+from pathlib import Path
+from typer.testing import CliRunner
+
+from wiki.cli import app
+
+runner = CliRunner()
+
+
+def test_preview_command(tmp_path, monkeypatch):
+    wiki_dir = tmp_path / "wiki"
+    work_dir = tmp_path / "work"
+    wiki_dir.mkdir()
+    work_dir.mkdir()
+
+    # Sample markdown and asset
+    (wiki_dir / "a.md").write_text("# A\n", encoding="utf-8")
+    assets = wiki_dir / "assets"
+    assets.mkdir()
+    (assets / "img.png").write_text("bin", encoding="utf-8")
+
+    index_path = work_dir / "index.yaml"
+    index_data = [{"section": "Sec", "pages": [{"title": "A", "path": "a.md", "visible": True}]}]
+    index_path.write_text(yaml.safe_dump(index_data, allow_unicode=True), encoding="utf-8")
+
+    monkeypatch.setattr("wiki.cli.cfg", {"paths": {"wiki": wiki_dir, "work": work_dir}})
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["preview"])
+    assert result.exit_code == 0
+
+    out_dir = tmp_path / "docs_web"
+    assert (out_dir / "index.html").exists()
+    assert (out_dir / "_sidebar.md").exists()
+    assert (out_dir / "a.md").exists()
+    assert (out_dir / "assets" / "img.png").exists()


### PR DESCRIPTION
## Summary
- implement `wiki preview` CLI command for generating a Docsify preview
- create `preview_generator` helper
- provide `render_sidebar_from_index` utility
- add tests for the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531345eccc83339365225334db3e64