### PR TITLE
Add configurable heading styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ The generated wiki will be placed in the `wiki/` directory. Open `wiki/index.htm
 - `wiki/` – final Markdown files and Docsify assets.
 - `docs/` – additional documentation (see `docs/arquitectura.md`).
 
+## Configuration
+
+The `config.yaml` file controls various aspects of the workflow. You can
+customise how headings are detected when building `map.yaml` by defining
+custom styles under the `headings:` key. For example:
+
+```yaml
+headings:
+  styles:
+    "!!": 1
+    "!": 2
+```
+
+If omitted, the default Markdown `#` markers are used.
+
 ## CLI reference
 
 ### `wiki index`

--- a/config.yaml
+++ b/config.yaml
@@ -20,3 +20,12 @@ menu:
   depth_limit: 2
   default_visible: true
   fallback_section: "99. Documentos no indexados"
+
+headings:
+  styles:
+    "#": 1
+    "##": 2
+    "###": 3
+    "####": 4
+    "#####": 5
+    "######": 6

--- a/src/wiki/processing/headings_map.py
+++ b/src/wiki/processing/headings_map.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import List, Dict
 
 import yaml
+from wiki.config import cfg
 from wiki.utils.slug import safe_slug
 
 used_slugs: set[str] = set()
@@ -25,15 +26,40 @@ def build_headings_map(
     map_data: List[Dict[str, str | int]] = []
     used_slugs.clear()
     counters: dict[int, int] = {}
+
+    styles_cfg = cfg.get("headings", {}).get("styles")
+    patterns: list[tuple[re.Pattern[str], int]] | None = None
+    if styles_cfg:
+        patterns = [
+            (re.compile(rf"^{re.escape(s)}\s+(.*)$"), int(level))
+            for s, level in sorted(styles_cfg.items(), key=lambda x: -len(x[0]))
+        ]
+
     for md_file in sorted(md_folder.rglob("*.md")):
         with md_file.open("r", encoding="utf-8") as f:
             for line in f:
-                m = HEADING_RE.match(line.strip())
-                if m:
+                stripped = line.strip()
+                if patterns:
+                    match = None
+                    level = 0
+                    title = ""
+                    for pat, lvl in patterns:
+                        m = pat.match(stripped)
+                        if m:
+                            match = m
+                            level = lvl
+                            title = m.group(1).strip()
+                            break
+                    if not match:
+                        continue
+                else:
+                    m = HEADING_RE.match(stripped)
+                    if not m:
+                        continue
                     level = len(m.group(1))
                     title = m.group(2).strip()
-                    if strip_numbers and level >= from_level:
-                        title = NUMBER_RE.sub("", title)
+                if strip_numbers and level >= from_level:
+                    title = NUMBER_RE.sub("", title)
 
                     counters[level] = counters.get(level, 0) + 1
                     for l in list(counters.keys()):

--- a/tests/test_headings_map.py
+++ b/tests/test_headings_map.py
@@ -61,3 +61,18 @@ def test_strip_numbers(tmp_path):
             "filename": "tercero.md",
         },
     ]
+
+
+def test_custom_styles(tmp_path, monkeypatch):
+    md_folder = tmp_path / "md_raw"
+    md_folder.mkdir()
+    md_file = md_folder / "sample.md"
+    md_file.write_text("!! H1\n! H2\n", encoding="utf-8")
+
+    custom_cfg = {"headings": {"styles": {"!!": 1, "!": 2}}}
+    import wiki.processing.headings_map as hm
+
+    monkeypatch.setattr(hm, "cfg", custom_cfg)
+    result = hm.build_headings_map(md_folder)
+    assert [r["level"] for r in result] == [1, 2]
+    assert [r["slug"] for r in result] == ["h1", "h2"]


### PR DESCRIPTION
## Summary
- make heading detection configurable via `config.yaml`
- document `headings.styles` option in README
- test custom heading styles

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685345e41a188333a6ece5eb753483b2