### PR TITLE
Implement fallback heading heuristics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ paths:
 options:
   allow_heading_heuristics: true
   fallback_to_heuristics_for_pdf: true
+  use_heuristic_headings: true
   ocr: true
   cutoff_similarity: 0.5
   discard_sections:

--- a/src/wiki/processing/normalization_utils.py
+++ b/src/wiki/processing/normalization_utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from statistics import mean
 from docx.text.paragraph import Paragraph
+from docx.document import Document
 
 from .style_map import HEADINGS_RULES
 
@@ -44,3 +46,45 @@ def should_use_heuristics(doc_path: Path, config: dict) -> bool:
     if opts.get("fallback_to_heuristics_for_pdf", False):
         return is_converted_from_pdf(doc_path)
     return False
+
+
+def average_font_size(document: Document) -> float:
+    """Return the average font size (pt) in the document."""
+    sizes: list[float] = []
+    for p in document.paragraphs:
+        for run in p.runs:
+            if run.font.size:
+                sizes.append(run.font.size.pt)
+    return mean(sizes) if sizes else 0.0
+
+
+def detect_heading_by_fallback(p: Paragraph, avg_size: float) -> int:
+    """Fallback heuristic detection based on bold, size and capitalization."""
+    if not p.text.strip() or avg_size <= 0:
+        return 0
+
+    runs = [r for r in p.runs if r.text.strip()]
+    if not runs:
+        return 0
+
+    max_size = 0.0
+    bold_count = 0
+    for r in runs:
+        if r.font.size and r.font.size.pt > max_size:
+            max_size = r.font.size.pt
+        if r.bold:
+            bold_count += 1
+
+    if max_size <= avg_size:
+        return 0
+
+    bold_ratio = bold_count / len(runs)
+    if bold_ratio < 0.5 and not p.text.isupper():
+        return 0
+
+    diff = max_size - avg_size
+    if diff > 4:
+        return 1
+    if diff > 2:
+        return 2
+    return 3

--- a/src/wiki/processing/normalize_docx.py
+++ b/src/wiki/processing/normalize_docx.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from docx import Document
+import logging
 
 from .normalization_utils import (
+    average_font_size,
+    detect_heading_by_fallback,
     detect_heading_by_heuristics,
     detect_heading_by_style,
     should_use_heuristics,
@@ -31,12 +34,23 @@ def normalize_styles(doc_path: Path, out_path: Path, cfg: dict | None = None) ->
     _remove_toc_paragraphs(document)
 
     use_heuristics = should_use_heuristics(doc_path, cfg)
+    use_fallback = cfg.get("options", {}).get("use_heuristic_headings", False)
+    avg_size = average_font_size(document) if use_fallback else 0.0
 
     for paragraph in document.paragraphs:
-        if use_heuristics:
+        level = detect_heading_by_style(paragraph)
+
+        if level == 0 and use_heuristics:
             level = detect_heading_by_heuristics(paragraph)
-        else:
-            level = detect_heading_by_style(paragraph)
+
+        if level == 0 and use_fallback:
+            level = detect_heading_by_fallback(paragraph, avg_size)
+            if level:
+                logging.warning(
+                    "Fallback heading detection used for paragraph: %s",
+                    paragraph.text[:50],
+                )
+
         if level:
             paragraph.style = f"Heading {level}"
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,5 +1,6 @@
 from docx import Document
 from docx.shared import Pt
+import logging
 
 from wiki.processing.normalize_docx import normalize_styles
 
@@ -36,3 +37,26 @@ def test_normalize_styles(tmp_path):
     assert doc.paragraphs[2].style.name == "Heading 3"
     assert doc.paragraphs[3].style.name == "Heading 4"
     assert doc.paragraphs[4].style.name == "Normal"
+
+
+def test_normalize_styles_fallback(tmp_path, caplog):
+    sample = tmp_path / "sample.docx"
+    doc = Document()
+
+    run_h1 = doc.add_paragraph().add_run("HEADING ONE")
+    run_h1.font.size = Pt(16)
+
+    run_body = doc.add_paragraph().add_run("Body text")
+    run_body.font.size = Pt(11)
+
+    doc.save(sample)
+
+    out = tmp_path / "out.docx"
+    cfg = {"options": {"allow_heading_heuristics": False, "fallback_to_heuristics_for_pdf": False, "use_heuristic_headings": True}}
+    caplog.set_level(logging.WARNING)
+    normalize_styles(sample, out, cfg)
+
+    assert any("Fallback heading detection" in rec.message for rec in caplog.records)
+
+    doc = Document(out)
+    assert doc.paragraphs[0].style.name.startswith("Heading")


### PR DESCRIPTION
## Summary
- configure fallback heading detection via `use_heuristic_headings`
- calculate average font size and detect headings when styles are missing
- warn when fallback heuristics are triggered
- test new fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685345ecda248333ac93492c7dd64084