### PR TITLE
Improve DOCX style fallback

### DIFF
--- a/src/wiki/processing/normalize_docx.py
+++ b/src/wiki/processing/normalize_docx.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from docx import Document
 import logging
+from ..tools.docx_utils import get_safe_heading_style
 
 from .normalization_utils import (
     average_font_size,
@@ -52,7 +53,8 @@ def normalize_styles(doc_path: Path, out_path: Path, cfg: dict | None = None) ->
                 )
 
         if level:
-            paragraph.style = f"Heading {level}"
+            safe_style = get_safe_heading_style(document, level)
+            paragraph.style = safe_style
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     document.save(str(out_path))

--- a/src/wiki/tools/docx_utils.py
+++ b/src/wiki/tools/docx_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import docx
 from docx.document import Document
 from docx.text.paragraph import Paragraph
+from docx.enum.style import WD_STYLE_TYPE
 
 # Heuristic thresholds for heading detection
 HEADING_1_MIN_FONT_SIZE = 14  # pt
@@ -37,6 +38,34 @@ def is_likely_heading(p: Paragraph) -> int:
     return 1 if base_score >= 2 else 0
 
 
+def get_safe_heading_style(doc: Document, target_level: int) -> str:
+    """Return a valid heading style name, falling back if needed."""
+    target = f"Heading {target_level}"
+    styles = [s.name for s in doc.styles if s.type == WD_STYLE_TYPE.PARAGRAPH]
+
+    if target in styles:
+        return target
+
+    fallback = None
+    for level in range(target_level - 1, 0, -1):
+        cand = f"Heading {level}"
+        if cand in styles:
+            fallback = cand
+            break
+
+    if not fallback:
+        fallback = "Heading 1" if "Heading 1" in styles else "Normal"
+
+    try:
+        new_style = doc.styles.add_style(target, WD_STYLE_TYPE.PARAGRAPH)
+        new_style.base_style = doc.styles[fallback]
+        print(f"⚠️ Estilo \"{target}\" no encontrado. Se ha clonado \"{fallback}\".")
+        return target
+    except Exception:
+        print(f"⚠️ Estilo \"{target}\" no encontrado. Se ha usado \"{fallback}\" como sustituto.")
+        return fallback
+
+
 def clean_docx_styles(doc_path: Path, output_path: Path) -> bool:
     """Normalize paragraphs to Heading styles if they look like titles."""
     try:
@@ -52,7 +81,8 @@ def clean_docx_styles(doc_path: Path, output_path: Path) -> bool:
         heading_level = is_likely_heading(p)
         if heading_level > 0:
             print(f"  -> '{p.text[:50].strip()}' \u2192 Heading {heading_level}")
-            p.style = f"Heading {heading_level}"
+            safe_style = get_safe_heading_style(doc, heading_level)
+            p.style = safe_style
             changes_made = True
 
     if changes_made:

--- a/src/wiki/tools/preprocess_documents.py
+++ b/src/wiki/tools/preprocess_documents.py
@@ -23,7 +23,7 @@ except Exception:
 
 from yaml import safe_load
 
-from .docx_utils import clean_docx_styles
+from .docx_utils import clean_docx_styles, get_safe_heading_style
 from . import pdf_utils
 
 # Re-export Converter for backwards compatibility with tests
@@ -37,7 +37,25 @@ def is_likely_heading(p: Paragraph) -> int:
     text = p.text.strip()
     if not text:
         return 0
-    return 0  # Placeholder logic, implement actual heuristics
+
+    if len(text.split()) > 12:
+        return 0
+
+    base_score = 1 if text.isupper() or text[0].isupper() else 0
+
+    bold_runs = [r.bold for r in p.runs if r.text.strip()]
+    if bold_runs:
+        bold_ratio = sum(1 for b in bold_runs if b) / len(bold_runs)
+        if bold_ratio >= 0.5:
+            base_score += 1
+
+    for r in p.runs:
+        if r.text.strip() and r.font.size:
+            if r.font.size.pt >= 13:
+                base_score += 1
+                break
+
+    return 1 if base_score >= 2 else 0
 
 def _remove_paragraphs(paragraphs: list[Paragraph]) -> None:
     for p in paragraphs:
@@ -111,7 +129,8 @@ def clean_docx_styles(doc_path: Path, output_path: Path, cfg: dict | None = None
         heading_level = is_likely_heading(p)
         if heading_level > 0:
             print(f"  → '{p.text[:50].strip()}' → Heading {heading_level}")
-            p.style = f'Heading {heading_level}'
+            safe_style = get_safe_heading_style(doc, heading_level)
+            p.style = safe_style
             changes_made = True
 
     if changes_made:

--- a/tests/test_clean_docx.py
+++ b/tests/test_clean_docx.py
@@ -43,3 +43,19 @@ def test_cli_clean_docx(tmp_path, monkeypatch):
     doc = Document(cleaned)
     assert doc.paragraphs[0].style.name == "Heading 1"
 
+
+def test_clean_docx_styles_missing_style(tmp_path):
+    dirty = tmp_path / "sample.docx"
+    cleaned = tmp_path / "cleaned.docx"
+    _create_dirty_docx(dirty)
+
+    # remove Heading 1 to force fallback
+    doc_tmp = Document(dirty)
+    style = doc_tmp.styles["Heading 1"]
+    doc_tmp.styles.element.remove(style._element)
+    doc_tmp.save(dirty)
+
+    clean_docx_styles(dirty, cleaned)
+    doc = Document(cleaned)
+    assert doc.paragraphs[0].style.name.startswith("Heading")
+

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -60,3 +60,24 @@ def test_normalize_styles_fallback(tmp_path, caplog):
 
     doc = Document(out)
     assert doc.paragraphs[0].style.name.startswith("Heading")
+
+
+def test_normalize_styles_missing_style(tmp_path):
+    sample = tmp_path / "sample.docx"
+    doc = Document()
+    run = doc.add_paragraph().add_run("H4 Title")
+    run.bold = True
+    run.italic = True
+    doc.save(sample)
+
+    # Remove Heading 4 style to force fallback
+    doc2 = Document(sample)
+    style = doc2.styles["Heading 4"]
+    doc2.styles.element.remove(style._element)
+    doc2.save(sample)
+
+    out = tmp_path / "out.docx"
+    normalize_styles(sample, out)
+
+    doc_out = Document(out)
+    assert doc_out.paragraphs[0].style.name.startswith("Heading")


### PR DESCRIPTION
## Summary
- add `get_safe_heading_style` helper to avoid missing style errors
- use it when normalizing documents
- update preprocess tools to use safe heading fallback
- add regression tests for missing styles

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q Pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534e1581f48333a4facf0c9fd1659c