### PR TITLE
Implement sidebar numbering and style mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+- Support custom Word styles `Nav_Tit_*` mapped to H1-H3.
+- Sidebar shows hierarchical numbers up to three levels.
+- Image paths normalized under `assets/media/`.
+- Avoid duplicated front-matter when source includes YAML.
+- Insert section numbers into page titles.
+- Menu depth limit increased to 3.

--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ options:
     contraportada: true
 
 menu:
-  depth_limit: 2
+  depth_limit: 3
   default_visible: true
   fallback_section: "99. Documentos no indexados"
 

--- a/src/wiki/cli.py
+++ b/src/wiki/cli.py
@@ -9,7 +9,7 @@ from .config import cfg
 from .processing.normalize_docx import normalize_styles
 from .processing.docx_to_md import convert_docx_to_md
 from .processing.headings_map import build_headings_map, save_map_yaml
-from .processing.ingest import ingest_content
+from .processing.ingest import ingest_content, insert_section_numbers
 from .processing.sidebar import build_sidebar
 from .tools.auto_index import auto_index_missing
 from .processing.reclassify import reclassify_unclassified
@@ -183,6 +183,10 @@ def full(
             doc_source=md.stem,
             cfg=cfg,
         )
+
+    with index_path.open("r", encoding="utf-8") as f:
+        index_data = yaml.safe_load(f) or []
+    insert_section_numbers(index_data, wiki_dir)
 
     console.print("[bold]Generating sidebar...[/bold]")
     abs_links = ctx.obj.get("absolute_links", False) if ctx.obj else False

--- a/src/wiki/processing/ingest.py
+++ b/src/wiki/processing/ingest.py
@@ -226,7 +226,12 @@ def ingest_content(
             if new_src not in sources:
                 sources.append(new_src)
 
-        _fm, body = _split_front_matter(text)
+        if text.lstrip().startswith("---\n"):
+            body = text
+            skip_meta = True
+        else:
+            skip_meta = False
+            _fm, body = _split_front_matter(text)
         header_lines = ["---", f"source: {md_path.name}"]
         if sources:
             if len(sources) == 1:
@@ -254,7 +259,16 @@ def ingest_content(
         if not any("fragment-meta" in line for line in body_lines[:5]):
             body = meta_line + body
 
-        final_text = post_process_text(hidden_yaml + body)
+        processed = post_process_text(body)
+        processed = fix_image_links(processed)
+        processed = normalize_image_paths(processed)
+        if skip_meta:
+            final_text = processed
+        else:
+            meta = post_process_text(hidden_yaml)
+            meta = fix_image_links(meta)
+            meta = normalize_image_paths(meta)
+            final_text = meta + processed
         final_text = fix_image_links(final_text)
         final_text = normalize_image_paths(final_text)
         assert "assets/assets/media/" not in final_text, "\u274c Doble ruta assets detectada"
@@ -328,3 +342,29 @@ def ingest_content(
         with (log_dir / "unclassified_report.txt").open("a", encoding="utf-8") as log_f:
             for sec_title, _ in unclassified_sections:
                 log_f.write(basic_slug(sec_title) + "\n")
+
+
+def insert_section_numbers(index_data: List[Dict[str, Any]], wiki_dir: Path) -> None:
+    """Insert numeric identifiers in H1 titles according to index data."""
+
+    def _walk(entries: List[Dict[str, Any]], depth: int = 1) -> None:
+        for entry in entries:
+            slug = entry.get("slug")
+            identifier = str(entry.get("id", ""))
+            title = str(entry.get("title", ""))
+            if depth <= 3 and slug and identifier and identifier[0].isdigit() and not title.lower().startswith("anexo"):
+                md_file = wiki_dir / f"{slug}.md"
+                if md_file.exists():
+                    lines = md_file.read_text(encoding="utf-8").splitlines(keepends=True)
+                    for i, line in enumerate(lines):
+                        if line.startswith("#"):
+                            m = re.match(r"^(#{1,6})\s+(.*)$", line)
+                            if m:
+                                prefix, text = m.groups()
+                                if not text.startswith(f"{identifier}. "):
+                                    lines[i] = f"{prefix} {identifier}. {text}\n"
+                            break
+                    md_file.write_text("".join(lines), encoding="utf-8")
+            _walk(entry.get("children") or [], depth + 1)
+
+    _walk(index_data)

--- a/src/wiki/processing/md_post.py
+++ b/src/wiki/processing/md_post.py
@@ -18,6 +18,8 @@ def fix_image_links(text: str) -> str:
     text = IMG_TAG_PREFIX_RE.sub(r"\1assets/media/", text)
     text = re.sub(r"(assets/)+media/", "assets/media/", text)
     text = re.sub(r"(media/)+", "media/", text)
+    text = re.sub(r"(\\|/)?assets/media/", "assets/media/", text)
+    text = re.sub(r"\.\./assets/media/", "assets/media/", text)
     return text
 
 

--- a/src/wiki/processing/normalize_docx.py
+++ b/src/wiki/processing/normalize_docx.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from docx import Document
 import logging
+
+STYLE_TO_LEVEL = {"Nav_Tit_1": 1, "Nav_Tit_2": 2, "Nav_Tit_3": 3}
 from ..tools.docx_utils import get_safe_heading_style
 
 from .normalization_utils import (
@@ -40,6 +42,11 @@ def normalize_styles(doc_path: Path, out_path: Path, cfg: dict | None = None) ->
 
     for paragraph in document.paragraphs:
         level = detect_heading_by_style(paragraph)
+
+        if level == 0:
+            style_name = paragraph.style.name if paragraph.style else ""
+            if style_name in STYLE_TO_LEVEL:
+                level = STYLE_TO_LEVEL[style_name]
 
         if level == 0 and use_heuristics:
             level = detect_heading_by_heuristics(paragraph)

--- a/src/wiki/processing/sidebar.py
+++ b/src/wiki/processing/sidebar.py
@@ -59,13 +59,18 @@ def _traverse_index(
         indent = "  " * (level - 1)
         if len(title) > 100:
             title = title[:97].rstrip() + "..."
+        display_title = (
+            f"{entry['id']}. {title}"
+            if str(entry.get('id', '')) and str(entry.get('id'))[0].isdigit()
+            else title
+        )
         if slug:
             link = f"/wiki/{filename}" if absolute else filename
             if level == 1 and lines:
                 lines.append("---")
-            lines.append(f"{indent}* [{title}]({link})")
+            lines.append(f"{indent}* [{display_title}]({link})")
         else:
-            lines.append(f"{indent}* {title}")
+            lines.append(f"{indent}* {display_title}")
         children = entry.get("children") or []
         _traverse_index(
             children,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,7 +109,7 @@ def test_index_overwrite(tmp_path, monkeypatch):
     assert result.exit_code == 0
     data = yaml.safe_load((work / "index.yaml").read_text(encoding="utf-8"))
     assert data[0]["id"] == "1"
-    assert not data[0]["children"][0]["children"]
+    assert data[0]["children"][0]["children"][0]["id"] == "1.1.1"
 
 
 def test_sidebar_command(tmp_path, monkeypatch):
@@ -126,7 +126,7 @@ def test_sidebar_command(tmp_path, monkeypatch):
     sidebar = work / "_sidebar.md"
     assert sidebar.exists()
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content == ["* [A](a.md)"]
+    assert content == ["* [1. A](a.md)"]
 
 
 def test_sidebar_command_absolute(tmp_path, monkeypatch):
@@ -142,7 +142,7 @@ def test_sidebar_command_absolute(tmp_path, monkeypatch):
     assert result.exit_code == 0
     sidebar = work / "_sidebar.md"
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content == ["* [A](/wiki/a.md)"]
+    assert content == ["* [1. A](/wiki/a.md)"]
 
 
 def test_search_index_command(tmp_path, monkeypatch):

--- a/tests/test_insert_numbers.py
+++ b/tests/test_insert_numbers.py
@@ -1,0 +1,31 @@
+import yaml
+from wiki.processing.ingest import ingest_content, insert_section_numbers
+
+
+def test_insert_numbers(tmp_path):
+    md = tmp_path / "doc.md"
+    md.write_text("# Intro\nTexto\n", encoding="utf-8")
+
+    index = [{"id": "1", "title": "Intro", "slug": "intro", "children": []}]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+
+    out_dir = tmp_path / "wiki"
+    ingest_content(md, index_path, out_dir, cutoff=0.5, doc_source="Doc")
+    insert_section_numbers(index, out_dir)
+    content = (out_dir / "intro.md").read_text(encoding="utf-8")
+    assert "# 1. Intro" in content
+
+
+def test_no_duplicate_front_matter(tmp_path):
+    md = tmp_path / "doc.md"
+    md.write_text("---\ntitle: X\n---\n# Intro\n", encoding="utf-8")
+
+    index = [{"id": "1", "title": "Intro", "slug": "intro", "children": []}]
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True), encoding="utf-8")
+
+    out_dir = tmp_path / "wiki"
+    ingest_content(md, index_path, out_dir, cutoff=0.5, doc_source="Doc")
+    text = (out_dir / "intro.md").read_text(encoding="utf-8")
+    assert text.count("---") == 2

--- a/tests/test_md_post.py
+++ b/tests/test_md_post.py
@@ -57,6 +57,15 @@ def test_fix_image_links_no_duplicate():
     assert fix_image_links(text) == text
 
 
+def test_fix_image_links_extra_prefix():
+    text = '![alt](/assets/media/img.png) ![](../assets/media/img2.png)'
+    fixed = fix_image_links(text)
+    assert '/assets/media/' not in fixed
+    assert '../assets/media/' not in fixed
+    assert 'assets/media/img.png' in fixed
+    assert 'assets/media/img2.png' in fixed
+
+
 def test_normalize_image_paths():
     text = '![alt](assets\\media\\img.png) and ![](C:/temp/foo.png)'
     result = normalize_image_paths(text)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -81,3 +81,26 @@ def test_normalize_styles_missing_style(tmp_path):
 
     doc_out = Document(out)
     assert doc_out.paragraphs[0].style.name.startswith("Heading")
+
+
+def test_normalize_nav_styles(tmp_path):
+    sample = tmp_path / "nav.docx"
+    doc = Document()
+    from docx.enum.style import WD_STYLE_TYPE
+    doc.styles.add_style("Nav_Tit_1", WD_STYLE_TYPE.PARAGRAPH)
+    doc.styles.add_style("Nav_Tit_2", WD_STYLE_TYPE.PARAGRAPH)
+    doc.styles.add_style("Nav_Tit_3", WD_STYLE_TYPE.PARAGRAPH)
+    doc.add_paragraph("Uno", style="Nav_Tit_1")
+    doc.add_paragraph("Dos", style="Nav_Tit_2")
+    doc.add_paragraph("Tres", style="Nav_Tit_3")
+    doc.save(sample)
+
+    out = tmp_path / "out.docx"
+    normalize_styles(sample, out)
+
+    doc_out = Document(out)
+    assert [p.style.name for p in doc_out.paragraphs[:3]] == [
+        "Heading 1",
+        "Heading 2",
+        "Heading 3",
+    ]

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -22,5 +22,36 @@ def test_sidebar_generation(tmp_path):
     build_sidebar(index_file, wiki_dir, absolute_links=False)
 
     sidebar_content = (wiki_dir / "_sidebar.md").read_text(encoding="utf-8")
-    assert "* [Introducción](introduccion.md)" in sidebar_content
-    assert "  * [Alcance](alcance.md)" in sidebar_content
+    assert "* [1. Introducción](introduccion.md)" in sidebar_content
+    assert "  * [1.1. Alcance](alcance.md)" in sidebar_content
+
+
+def test_sidebar_numbers(tmp_path):
+    index_file = tmp_path / "index.yaml"
+    index_file.write_text(
+        """
+- id: '2'
+  title: Sistemas
+  slug: sistemas
+  children:
+    - id: '2.1'
+      title: Servicios
+      slug: servicios
+      children:
+        - id: '2.1.3'
+          title: Interfaces SSIS
+          slug: interfaces-ssis
+          children: []
+""",
+        encoding="utf-8",
+    )
+
+    wiki_dir = tmp_path / "wiki"
+    wiki_dir.mkdir()
+    for slug in ["sistemas", "servicios", "interfaces-ssis"]:
+        (wiki_dir / f"{slug}.md").write_text("# T\n", encoding="utf-8")
+
+    build_sidebar(index_file, wiki_dir, absolute_links=False)
+
+    sidebar = (wiki_dir / "_sidebar.md").read_text(encoding="utf-8")
+    assert "2.1.3. Interfaces SSIS" in sidebar

--- a/tests/test_sidebar_filter.py
+++ b/tests/test_sidebar_filter.py
@@ -28,4 +28,4 @@ def test_sidebar_filters(tmp_path, monkeypatch):
     sidebar = tmp_path / "_sidebar.md"
     assert sidebar.exists()
     content = sidebar.read_text(encoding="utf-8").splitlines()
-    assert content == ["* [A](a.md)"]
+    assert content == ["* [1. A](a.md)"]

--- a/tests/test_sidebar_visible.py
+++ b/tests/test_sidebar_visible.py
@@ -26,4 +26,4 @@ def test_sidebar_visible_flag(tmp_path, monkeypatch):
     result = runner.invoke(app, ["sidebar"])
     assert result.exit_code == 0
     content = (tmp_path / "_sidebar.md").read_text(encoding="utf-8").splitlines()
-    assert content == ["* Sec", "  * [A](a.md)"]
+    assert content == ["* 1. Sec", "  * [1.1. A](a.md)"]


### PR DESCRIPTION
## Summary
- map custom Nav_Tit_* styles to headings
- bump menu depth limit
- prefix sidebar links with numeric ids
- normalize asset paths in Markdown
- avoid duplicate front matter
- add section numbering to page titles
- update CLI to call numbering step
- add tests for new features
- document changes in CHANGELOG

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686257b6fb2c8333a92a4b66f126bdd5